### PR TITLE
Add --client, --dump, --restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 27017
 
 ADD run-database.sh /usr/bin/
+ADD utilities.sh /usr/bin/
 ENTRYPOINT ["run-database.sh"]

--- a/run-database.sh
+++ b/run-database.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+. /usr/bin/utilities.sh
+
+command="/usr/bin/mongod --dbpath "$DATA_DIRECTORY" --auth"
+dump_directory="mongodump"
 if [[ "$1" == "--initialize" ]]; then
   PID_PATH=/tmp/mongod.pid
   mongod --dbpath "$DATA_DIRECTORY" --fork --logpath /dev/null --pidfilepath "$PID_PATH"
@@ -8,7 +12,43 @@ if [[ "$1" == "--initialize" ]]; then
   kill $(cat $PID_PATH)
   # wait for lock file to be released
   while [ -s "$DATA_DIRECTORY"/mongod.lock ]; do sleep 0.1; done
-  exit
-fi
 
-/usr/bin/mongod --dbpath "$DATA_DIRECTORY" --auth
+elif [[ "$1" == "--client" ]]; then
+  [ -z "$2" ] && echo "docker run -it aptible/mongodb --client mongodb://..." && exit
+  parse_url "$2"
+  mongo --host="$host" --port="${port:-27017}" --username="$user" --password="$password" "$database"
+
+elif [[ "$1" == "--dump" ]]; then
+  [ -z "$2" ] && echo "docker run aptible/mongodb --dump mongodb://... > dump.mongo" && exit
+  # https://jira.mongodb.org/browse/SERVER-7860
+  # Can't dump the whole database to stdout in a straightforward way. Instead,
+  # dump to a directory and then tar the directory and print the tar to stdout.
+  parse_url "$2"
+  dump_command="mongodump --host="$host" --port="${port:-27017}" --username="$user" --password="$password" --db="$database" --out=/tmp/"$dump_directory""
+  $dump_command > /dev/null && tar cf - -C /tmp/ "$dump_directory"
+
+elif [[ "$1" == "--restore" ]]; then
+  [ -z "$2" ] && echo "docker run -i aptible/mongodb --restore mongodb://... < dump.mongo" && exit
+  tar xf - -C /tmp/
+  parse_url "$2"
+  mongorestore --host="$host" --port="${port:-27017}" --username="$user" --password="$password" --db="$database" /tmp/"$dump_directory"/"$database"
+
+elif [[ "$1" == "--readonly" ]]; then
+  # MongoDB only supports read-only mode on a per-user basis. To make that
+  # happen, it should be possible to mimic the `--initialize` sequence to set
+  # the user's `roles` to [ "read" ].
+  #
+  # This presents some difficulties:
+  # * no $USERNAME is being passed.
+  # * normal invocations of the server would need to ensure the user wasn't in
+  #     read-only mode.
+  # * temporarily starting the daemon to make the change is ugly.
+  #
+  # With all of that said, leaving off read-only mode for now.
+  echo "This image does not support read-only mode. Starting database normally."
+  $command
+
+else
+  $command
+
+fi

--- a/test/mongodb.bats
+++ b/test/mongodb.bats
@@ -2,7 +2,7 @@
 
 @test "It should install mongod " {
   run mongod --version
-  [[ "$output" =~ "db version v2.6.8"  ]]
+  [[ "$output" =~ "db version v2.6.9"  ]]
 }
 
 @test "It should install mongod to /usr/bin/mongod" {

--- a/utilities.sh
+++ b/utilities.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+parse_url()
+{
+  # cf http://stackoverflow.com/a/17287984
+  protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+  # remove the protocol
+  url=$(echo $1 | sed -e s,$protocol,,g)
+  # extract the user and password (if any)
+  user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
+  password="$(echo $user_and_password | grep : | cut -d: -f2)"
+  if [ -n "$password" ]; then
+    user="$(echo $user_and_password | grep : | cut -d: -f1)"
+  else
+    user="$user_and_password"
+  fi
+
+  # extract the host
+  host_and_port="$(echo $url | sed -e s,$user_and_password@,,g | cut -d/ -f1)"
+  port="$(echo $host_and_port | grep : | cut -d: -f2)"
+  if [ -n "$port" ]; then
+    host="$(echo $host_and_port | grep : | cut -d: -f1)"
+  else
+    host="$host_and_port"
+  fi
+
+  database="$(echo $url | grep / | cut -d/ -f2-)"
+}


### PR DESCRIPTION
This PR adds some functionality to the MongoDB image. Notes:

* `mongodump` supports dumping individual collections to stdout, but not an entire database. It can dump a database to the file system, though. As a result, `--dump` tars the resulting files and prints the tarball to stdout.
* `--restore` reverses the `--dump` process: it untars and then imports.
* There are some obstacles to enabling read-only mode for MongoDB. I've documented them in comments in `run-database.sh`, and left the functionality out.