### PR TITLE
MongoDB 3.2

### DIFF
--- a/2.6/test/mongodb.bats
+++ b/2.6/test/mongodb.bats
@@ -2,7 +2,7 @@
 
 @test "It should install mongod " {
   run mongod --version
-  [[ "$output" =~ "db version v2.6.10"  ]]
+  [[ "$output" =~ "db version v2.6.11"  ]]
 }
 
 @test "It should install mongod to /usr/bin/mongod" {

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -1,0 +1,27 @@
+FROM quay.io/aptible/debian:wheezy
+
+ENV MONGO_VERSION 3.2.1
+ENV DATA_DIRECTORY /var/db
+ENV SSL_DIRECTORY /etc/ssl/mongodb
+
+# Install latest MongoDB from custom package repo
+ADD templates/mongodb.list /etc/apt/sources.list.d/mongodb.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv EA312927 && \
+    apt-install adduser procps \
+      mongodb-org=$MONGO_VERSION mongodb-org-server=$MONGO_VERSION \
+      mongodb-org-shell=$MONGO_VERSION mongodb-org-mongos=$MONGO_VERSION \
+      mongodb-org-tools=$MONGO_VERSION && \
+    mkdir -p "$DATA_DIRECTORY"
+
+ADD run-database.sh /usr/bin/
+ADD utilities.sh /usr/bin/
+
+# Integration tests
+ADD test /tmp/test
+RUN bats /tmp/test
+
+VOLUME ["$DATA_DIRECTORY"]
+VOLUME ["$SSL_DIRECTORY"]
+EXPOSE 27017
+
+ENTRYPOINT ["run-database.sh"]

--- a/3.2/run-database.sh
+++ b/3.2/run-database.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+. /usr/bin/utilities.sh
+
+function startMongod() {
+  SUBJ="/C=US/ST=New York/L=New York/O=Example/CN=mongodb.example.com"
+  if [ ! -f "$SSL_DIRECTORY"/mongodb.crt ] && [ ! -f "$SSL_DIRECTORY"/mongodb.key ]; then
+    OPTS="req -nodes -new -x509 -sha256"
+    openssl $OPTS -subj "$SUBJ" -keyout "$SSL_DIRECTORY"/mongodb.key -out "$SSL_DIRECTORY"/mongodb.crt 2> /dev/null
+  fi
+
+  cat $SSL_DIRECTORY/mongodb.key $SSL_DIRECTORY/mongodb.crt > $SSL_DIRECTORY/mongodb.pem
+  exec /usr/bin/mongod --dbpath "$DATA_DIRECTORY" --auth --sslMode requireSSL --sslPEMKeyFile $SSL_DIRECTORY/mongodb.pem
+}
+
+dump_directory="mongodump"
+if [[ "$1" == "--initialize" ]]; then
+  mkdir -p $SSL_DIRECTORY
+
+  if [ -n "$SSL_CERTIFICATE" ] && [ -n "$SSL_KEY" ]; then
+    echo "$SSL_CERTIFICATE" > "$SSL_DIRECTORY"/mongodb.crt
+    echo "$SSL_KEY" > "$SSL_DIRECTORY"/mongodb.key
+  fi
+
+  PID_PATH=/tmp/mongod.pid
+  mongod --dbpath "$DATA_DIRECTORY" --fork --logpath /dev/null --pidfilepath "$PID_PATH"
+  mongo db --eval "db.createUser({\"user\":\"${USERNAME:-aptible}\",\"pwd\":\"$PASSPHRASE\",\"roles\":[\"dbOwner\"]}, {\"w\":1,\"j\":true})"
+
+  kill $(cat $PID_PATH)
+  # wait for lock file to be released
+  while [ -s "$DATA_DIRECTORY"/mongod.lock ]; do sleep 0.1; done
+
+elif [[ "$1" == "--client" ]]; then
+  [ -z "$2" ] && echo "docker run -it aptible/mongodb --client mongodb://..." && exit
+  parse_url "$2"
+  mongo --host="$host" --port="${port:-27017}" --username="$user" --password="$password" --ssl --sslCAFile /etc/ssl/certs/ca-certificates.crt "$database"
+
+elif [[ "$1" == "--dump" ]]; then
+  [ -z "$2" ] && echo "docker run aptible/mongodb --dump mongodb://... > dump.mongo" && exit
+  # https://jira.mongodb.org/browse/SERVER-7860
+  # Can't dump the whole database to stdout in a straightforward way. Instead,
+  # dump to a directory and then tar the directory and print the tar to stdout.
+  parse_url "$2"
+  dump_command="mongodump --host="$host" --port="${port:-27017}" --username="$user" --password="$password" --db="$database" --out=/tmp/"$dump_directory""
+  $dump_command > /dev/null && tar cf - -C /tmp/ "$dump_directory"
+
+elif [[ "$1" == "--restore" ]]; then
+  [ -z "$2" ] && echo "docker run -i aptible/mongodb --restore mongodb://... < dump.mongo" && exit
+  tar xf - -C /tmp/
+  parse_url "$2"
+  mongorestore --host="$host" --port="${port:-27017}" --username="$user" --password="$password" --db="$database" /tmp/"$dump_directory"/"$database"
+
+elif [[ "$1" == "--readonly" ]]; then
+  # MongoDB only supports read-only mode on a per-user basis. To make that
+  # happen, it should be possible to mimic the `--initialize` sequence to set
+  # the user's `roles` to [ "read" ].
+  #
+  # This presents some difficulties:
+  # * no $USERNAME is being passed.
+  # * normal invocations of the server would need to ensure the user wasn't in
+  #     read-only mode.
+  # * temporarily starting the daemon to make the change is ugly.
+  #
+  # With all of that said, leaving off read-only mode for now.
+  echo "This image does not support read-only mode. Starting database normally."
+  startMongod
+
+else
+  startMongod
+
+fi

--- a/3.2/templates/mongodb.list
+++ b/3.2/templates/mongodb.list
@@ -1,0 +1,1 @@
+deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.2 main

--- a/3.2/test/mongodb.bats
+++ b/3.2/test/mongodb.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+setup() {
+  export OLD_DATA_DIRECTORY="$DATA_DIRECTORY"
+  export OLD_SSL_DIRECTORY="$SSL_DIRECTORY"
+  export DATA_DIRECTORY=/tmp/datadir
+  export SSL_DIRECTORY=/tmp/ssldir
+  export QUERY="db.getCollectionNames()"
+  rm -rf "$DATA_DIRECTORY"
+  rm -rf "$SSL_DIRECTORY"
+  mkdir -p "$DATA_DIRECTORY"
+  mkdir -p "$SSL_DIRECTORY"
+}
+
+teardown() {
+  export DATA_DIRECTORY="$OLD_DATA_DIRECTORY"
+  export SSL_DIRECTORY="$OLD_SSL_DIRECTORY"
+  unset OLD_DATA_DIRECTORY
+  unset OLD_SSL_DIRECTORY
+  PID=$(pgrep mongod) || return 0
+  run pkill mongod
+  while [ -n "$PID" ] && [ -e /proc/$PID ]; do sleep 0.1; done
+}
+
+wait_for_mongodb() {
+  run-database.sh > $BATS_TEST_DIRNAME/mongodb.log &
+  while  ! grep "waiting for connections" $BATS_TEST_DIRNAME/mongodb.log ; do sleep 0.1; done
+}
+
+@test "It should install mongod " {
+  run mongod --version
+  [[ "$output" =~ "db version v3.2.1"  ]]
+}
+
+@test "It should install mongod to /usr/bin/mongod" {
+  test -x /usr/bin/mongod
+}
+
+@test "It should reject non-SSL connections" {
+  USERNAME=aptible PASSPHRASE=password run-database.sh --initialize
+  wait_for_mongodb
+  run mongo --username aptible --password password db --eval "$QUERY"
+  [ "$status" -ne "0" ]
+}
+
+@test "It should accept SSL connections" {
+  USERNAME=aptible PASSPHRASE=password run-database.sh --initialize
+  wait_for_mongodb
+  run mongo --ssl --sslAllowInvalidCertificates --username aptible --password password db --eval "$QUERY"
+  [ "$status" -eq "0" ]
+  [[ "$output" =~ "[ ]" ]]
+}

--- a/3.2/utilities.sh
+++ b/3.2/utilities.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+parse_url()
+{
+  # cf http://stackoverflow.com/a/17287984
+  protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+  # remove the protocol
+  url=$(echo $1 | sed -e s,$protocol,,g)
+  # extract the user and password (if any)
+  user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
+  password="$(echo $user_and_password | grep : | cut -d: -f2)"
+  if [ -n "$password" ]; then
+    user="$(echo $user_and_password | grep : | cut -d: -f1)"
+  else
+    user="$user_and_password"
+  fi
+
+  # extract the host
+  host_and_port="$(echo $url | sed -e s,$user_and_password@,,g | cut -d/ -f1)"
+  port="$(echo $host_and_port | grep : | cut -d: -f2)"
+  if [ -n "$port" ]; then
+    host="$(echo $host_and_port | grep : | cut -d: -f1)"
+  else
+    host="$host_and_port"
+  fi
+
+  database="$(echo $url | grep / | cut -d/ -f2-)"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER = docker
 REPO = git@github.com:aptible/docker-mongodb.git
-TAGS = 2.6
+TAGS = 2.6 3.2
 
 all: release
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ The first command sets up a data container named `data` which will hold the conf
 
 ## Available Tags
 
-* `latest`: Currently MongoDB 2.6.10
-* `2.6`: MongoDB 2.6.10
+* `latest`: Currently MongoDB 3.2.1
+* `2.6`: MongoDB 2.6.11
+* `3.2`: MongoDB 3.2.1
 
 ## Tests
 


### PR DESCRIPTION
From pairing w/ @krallin 

This adds support for MongoDB 3.2, with ` { sslMode: 'requireSSL' }`. Two new integration tests have been added, to ensure that connections are accepted over SSL, and rejected without SSL.

We'll plan to backport SSL support to 2.6 as well. Because of limited client support for SSL on 2.6, we'll opt to use `{ sslMode: 'allowSSL' }` there.