### PR TITLE
Install MongoDB 2.6.11 with SSL support

### DIFF
--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -1,19 +1,30 @@
 FROM quay.io/aptible/debian:wheezy
 
-ENV DATA_DIRECTORY /var/db
+ENV MONGO_VERSION 2.6.11
 
-# Install latest MongoDB from custom package repo
+# Compile and install MongoDB "core"
+ADD ./install-mongodb.sh /install-mongodb.sh
+RUN /install-mongodb.sh
+
+# Install MongoDB tools (we're not compiling those from source)
 ADD templates/mongodb.list /etc/apt/sources.list.d/mongodb.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10 && \
-    apt-get update && apt-get install -y adduser mongodb-org && mkdir -p "$DATA_DIRECTORY"
+    apt-install "mongodb-org-tools=${MONGO_VERSION}" procps ca-certificates
+
+ENV DATA_DIRECTORY /var/db
+ENV SSL_DIRECTORY /etc/ssl/mongo
+RUN mkdir -p "${DATA_DIRECTORY}" "${SSL_DIRECTORY}"
+
+# Tools
+ADD run-database.sh /usr/bin/
+ADD utilities.sh /usr/bin/
 
 # Integration tests
 ADD test /tmp/test
 RUN bats /tmp/test
 
 VOLUME ["$DATA_DIRECTORY"]
+VOLUME ["$SSL_DIRECTORY"]
 EXPOSE 27017
 
-ADD run-database.sh /usr/bin/
-ADD utilities.sh /usr/bin/
 ENTRYPOINT ["run-database.sh"]

--- a/2.6/install-mongodb.sh
+++ b/2.6/install-mongodb.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+MONGO_NAME="mongodb-src-r${MONGO_VERSION}"
+MONGO_ARCHIVE="${MONGO_NAME}.tar.gz"
+MONGO_URL="https://fastdl.mongodb.org/src/${MONGO_ARCHIVE}"
+MONGO_PACKAGE="$(basename "${MONGO_URL}")"
+MONGO_BUILD_DEPS=(build-essential scons libssl-dev wget checkinstall)
+MONGO_INSTALL_GROUP="core"
+
+MONGO_PACKAGES_PKGLIST="mongodb-org, mongodb-org-server, mongodb-org-shell, mongodb-org-mongos"
+MONGO_RUNDEPS_PKGLIST="libc6, libgcc1, libssl1.0.0, libstdc++6, adduser"
+
+apt-get update
+apt-get install -y adduser  # Runtime dep
+apt-get install -y "${MONGO_BUILD_DEPS[@]}"  # Build-time deps
+
+mongo_build_dir="/tmp/mongo-build"
+mkdir "${mongo_build_dir}"
+cd "${mongo_build_dir}"
+
+wget "${MONGO_URL}"
+tar -xf "${MONGO_ARCHIVE}"
+cd "${MONGO_NAME}"
+
+echo "MongoDB build from source by Aptible" > description-pak
+
+checkinstall \
+  --type=debian \
+  --install=yes \
+  --pkgname="mongodb-aptible-${MONGO_INSTALL_GROUP}" \
+  --pkgversion="${MONGO_VERSION}" \
+  --pkggroup="database" \
+  --maintainer="thomas@aptible.com" \
+  --replaces="${MONGO_PACKAGES_PKGLIST}" \
+  --provides="${MONGO_PACKAGES_PKGLIST}" \
+  --conflicts="${MONGO_PACKAGES_PKGLIST}" \
+  --requires="${MONGO_RUNDEPS_PKGLIST}" \
+  --nodoc --fstrans=no -y \
+  scons -j "$(nproc)" "${MONGO_INSTALL_GROUP}" install --ssl
+
+cd /
+rm -rf "${mongo_build_dir}"
+
+apt-get remove -y "${MONGO_BUILD_DEPS[@]}"
+apt-get autoremove -y
+rm -rf /var/lib/apt/lists/*
+

--- a/2.6/test/mongodb.bats
+++ b/2.6/test/mongodb.bats
@@ -1,10 +1,55 @@
 #!/usr/bin/env bats
+setup() {
+  export OLD_DATA_DIRECTORY="$DATA_DIRECTORY"
+  export OLD_SSL_DIRECTORY="$SSL_DIRECTORY"
+  export DATA_DIRECTORY=/tmp/datadir
+  export SSL_DIRECTORY=/tmp/ssldir
+  export QUERY="JSON.stringify(db.getCollectionNames())"
+  rm -rf "$DATA_DIRECTORY"
+  rm -rf "$SSL_DIRECTORY"
+  mkdir -p "$DATA_DIRECTORY"
+  mkdir -p "$SSL_DIRECTORY"
+}
+
+teardown() {
+  export DATA_DIRECTORY="$OLD_DATA_DIRECTORY"
+  export SSL_DIRECTORY="$OLD_SSL_DIRECTORY"
+  unset OLD_DATA_DIRECTORY
+  unset OLD_SSL_DIRECTORY
+  PID=$(pgrep mongod) || return 0
+  run pkill mongod
+  while [ -n "$PID" ] && [ -e /proc/$PID ]; do sleep 0.1; done
+}
+
+wait_for_mongodb() {
+  run-database.sh > $BATS_TEST_DIRNAME/mongodb.log &
+  while  ! grep "waiting for connections" $BATS_TEST_DIRNAME/mongodb.log ; do sleep 0.1; done
+}
 
 @test "It should install mongod " {
   run mongod --version
-  [[ "$output" =~ "db version v2.6.10"  ]]
+  [[ "$output" =~ "db version v2.6.11"  ]]
 }
 
-@test "It should install mongod to /usr/bin/mongod" {
-  test -x /usr/bin/mongod
+@test "It should install mongo tools to /usr/local/bin" {
+  test -x /usr/local/bin/mongod
+  test -x /usr/local/bin/mongo
+  test -x /usr/local/bin/mongorestore
+  test -x /usr/local/bin/mongodump
+}
+
+@test "It should accept non-SSL connections" {
+  USERNAME=aptible PASSPHRASE=password run-database.sh --initialize
+  wait_for_mongodb
+  run mongo --username aptible --password password db --eval "$QUERY"
+  [ "$status" -eq "0" ]
+  [[ "$output" =~ "[]" ]]
+}
+
+@test "It should accept SSL connections" {
+  USERNAME=aptible PASSPHRASE=password run-database.sh --initialize
+  wait_for_mongodb
+  run mongo --ssl --sslAllowInvalidCertificates --username aptible --password password db --eval "$QUERY"
+  [ "$status" -eq "0" ]
+  [[ "$output" =~ "[]" ]]
 }


### PR DESCRIPTION
This is a backport of #10 for MongoDB 2.6.

@fancyremarker , a few thinks I'd like to call out:

+ I think we should consider testing the dump / restore functionality. I'm not sure whether those tools ship with MongoDB "core" or MongoDB "tools", so I'd like to double-check they work properly.
+ This installs to `/usr/local`. I can change it to `/usr` if that's a problem.
+ I think with a few tweaks to the `run-database.sh` script in #10, we could use the exact same script for both versions (which might ease maintainability). I think this would be in our best interest. I'm happy to take care of it. 
+ I had to alter the query a little bit. For some reason, on Mongo 2.6.11, there's no output unless I use `JSON.stringify`.

Cheers,