### PR TITLE
Ensure --client is consistent with MongoDB clients

### DIFF
--- a/2.6/parse_mongo_url.py
+++ b/2.6/parse_mongo_url.py
@@ -3,7 +3,7 @@
 The output from this script is meant to be eval'd by a shell to parse out MongoDB options
 from a connection string.
 
->>> mongo_url = urlparse.urlparse("mongodb://aptible:foobar@localhost:123/db?uri.ssl=true&uri.x-sslVerify=false")
+>>> mongo_url = urlparse.urlparse("mongodb://aptible:foobar@localhost:123/db?ssl=true&x-sslVerify=false")
 >>> options = prepare_options(mongo_url)
 >>> assert options["host"] == "localhost"
 >>> assert options["port"] == 123
@@ -12,7 +12,7 @@ from a connection string.
 >>> assert "--sslAllowInvalidCertificates" in options["mongo_options"]
 >>> assert "--ssl" in options["mongo_options"]
 
->>> mongo_url = urlparse.urlparse("mongodb://aptible:foobar@localhost:123/db?uri.ssl=true")
+>>> mongo_url = urlparse.urlparse("mongodb://aptible:foobar@localhost:123/db?ssl=true")
 >>> options = prepare_options(mongo_url)
 >>> assert "--sslAllowInvalidCertificates" not in options["mongo_options"]
 >>> assert "--ssl" in options["mongo_options"]
@@ -29,9 +29,9 @@ SSL_CA_FILE = "/etc/ssl/certs/ca-certificates.crt"
 
 def qs_uses_ssl(qs):
     """
-    By default, we don't use SSL. If ?uri.ssl=true is found, we do.
+    By default, we don't use SSL. If ?ssl=true is found, we do.
     """
-    for ssl_value in qs.get('uri.ssl', []):
+    for ssl_value in qs.get('ssl', []):
         if ssl_value == "true":
             return True
     return False
@@ -39,10 +39,10 @@ def qs_uses_ssl(qs):
 
 def qs_checks_ssl(qs):
     """
-    By default, we check SSL certificate validity. If ?uri.x-sslVerify=false is found, we don't.
+    By default, we check SSL certificate validity. If ?x-sslVerify=false is found, we don't.
     We prepend x- to the option because it's non-standard in MongoDB connection strings.
     """
-    for check_ssl_value in qs.get("uri.x-sslVerify", []):
+    for check_ssl_value in qs.get("x-sslVerify", []):
         if check_ssl_value == "false":
             return False
     return True

--- a/2.6/test/mongodb.bats
+++ b/2.6/test/mongodb.bats
@@ -9,7 +9,7 @@ setup() {
   export DATABASE_USER="aptible"
   export DATABASE_PASSWORD="password12345"
   export DATABASE_URL_NO_SSL="mongodb://$DATABASE_USER:$DATABASE_PASSWORD@localhost/db"
-  export DATABASE_URL="$DATABASE_URL_NO_SSL?uri.ssl=true&uri.x-sslVerify=false"
+  export DATABASE_URL="$DATABASE_URL_NO_SSL?ssl=true&x-sslVerify=false"
   rm -rf "$DATA_DIRECTORY"
   rm -rf "$SSL_DIRECTORY"
   mkdir -p "$DATA_DIRECTORY"

--- a/3.2/parse_mongo_url.py
+++ b/3.2/parse_mongo_url.py
@@ -3,7 +3,7 @@
 The output from this script is meant to be eval'd by a shell to parse out MongoDB options
 from a connection string.
 
->>> mongo_url = urlparse.urlparse("mongodb://aptible:foobar@localhost:123/db?uri.ssl=true&uri.x-sslVerify=false")
+>>> mongo_url = urlparse.urlparse("mongodb://aptible:foobar@localhost:123/db?ssl=true&x-sslVerify=false")
 >>> options = prepare_options(mongo_url)
 >>> assert options["host"] == "localhost"
 >>> assert options["port"] == 123
@@ -12,7 +12,7 @@ from a connection string.
 >>> assert "--sslAllowInvalidCertificates" in options["mongo_options"]
 >>> assert "--ssl" in options["mongo_options"]
 
->>> mongo_url = urlparse.urlparse("mongodb://aptible:foobar@localhost:123/db?uri.ssl=true")
+>>> mongo_url = urlparse.urlparse("mongodb://aptible:foobar@localhost:123/db?ssl=true")
 >>> options = prepare_options(mongo_url)
 >>> assert "--sslAllowInvalidCertificates" not in options["mongo_options"]
 >>> assert "--ssl" in options["mongo_options"]
@@ -29,9 +29,9 @@ SSL_CA_FILE = "/etc/ssl/certs/ca-certificates.crt"
 
 def qs_uses_ssl(qs):
     """
-    By default, we don't use SSL. If ?uri.ssl=true is found, we do.
+    By default, we don't use SSL. If ?ssl=true is found, we do.
     """
-    for ssl_value in qs.get('uri.ssl', []):
+    for ssl_value in qs.get('ssl', []):
         if ssl_value == "true":
             return True
     return False
@@ -39,10 +39,10 @@ def qs_uses_ssl(qs):
 
 def qs_checks_ssl(qs):
     """
-    By default, we check SSL certificate validity. If ?uri.x-sslVerify=false is found, we don't.
+    By default, we check SSL certificate validity. If ?x-sslVerify=false is found, we don't.
     We prepend x- to the option because it's non-standard in MongoDB connection strings.
     """
-    for check_ssl_value in qs.get("uri.x-sslVerify", []):
+    for check_ssl_value in qs.get("x-sslVerify", []):
         if check_ssl_value == "false":
             return False
     return True

--- a/3.2/test/mongodb.bats
+++ b/3.2/test/mongodb.bats
@@ -9,7 +9,7 @@ setup() {
   export DATABASE_USER="aptible"
   export DATABASE_PASSWORD="password12345"
   export DATABASE_URL_NO_SSL="mongodb://$DATABASE_USER:$DATABASE_PASSWORD@localhost/db"
-  export DATABASE_URL="$DATABASE_URL_NO_SSL?uri.ssl=true&uri.x-sslVerify=false"
+  export DATABASE_URL="$DATABASE_URL_NO_SSL?ssl=true&x-sslVerify=false"
   rm -rf "$DATA_DIRECTORY"
   rm -rf "$SSL_DIRECTORY"
   mkdir -p "$DATA_DIRECTORY"


### PR DESCRIPTION
This ensures consistency with MongoDB clients regarding handling of the `ssl` parameter.

---

Commit message follows:

Despite what the docs seem to be saying, the SSL parameter for MongoDB
is `ssl`, not `uri.ssl`. Ensure our client uses the same conventions.