### PR TITLE
Mongodb replication

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -13,7 +13,7 @@ ADD <%= ENV.fetch 'TAG' %>/install-mongodb.sh /install-mongodb.sh
 RUN /install-mongodb.sh
 
 # Install MongoDB tools and utilities we need
-RUN apt-install "mongodb-org-tools=${MONGO_VERSION}" adduser procps ca-certificates python
+RUN apt-install "mongodb-org-tools=${MONGO_VERSION}" adduser procps ca-certificates python pwgen
 
 # Configuration
 ENV MONGO_SSL_MODE <%= ENV.fetch "MONGO_SSL_MODE" %>
@@ -25,6 +25,8 @@ RUN mkdir -p "${DATA_DIRECTORY}" "${SSL_DIRECTORY}"
 ADD bin/run-database.sh /usr/bin/
 ADD bin/parse_mongo_url.py /usr/bin/
 ADD bin/utilities.sh /usr/bin/
+
+ADD templates/mongo-scripts /mongo-scripts
 
 # Integration tests
 ADD <%= ENV.fetch 'TAG' %>/test /tmp/test

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MongoDB on Docker
 This is an image conforming to the [Aptible database specification](https://support.aptible.com/topics/paas/deploy-custom-database/). To run a server for development purposes, execute
 
     docker create --name data quay.io/aptible/mongodb
-    docker run --volumes-from data -e USERNAME=aptible -e PASSPHRASE=pass -e DB=db quay.io/aptible/mongodb --initialize
+    docker run --volumes-from data -e USERNAME=aptible -e PASSPHRASE=pass -e DATABASE=db quay.io/aptible/mongodb --initialize
     docker run --volumes-from data -P quay.io/aptible/mongodb
 
 The first command sets up a data container named `data` which will hold the configuration and data for the database. The second command creates a MongoDB instance with a username, passphrase and database name of your choice. The third command starts the database server.

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -165,13 +165,14 @@ function startMongod () {
     "--auth"
   )
 
-  if [ -f "$REPL_SET_NAME_FILE" ]; then
-    # We have a replica set name file: expand the configuration
-    # to start as a replica set member.
+  if [ -f "$REPL_SET_NAME_FILE" ] && [ -f "$CLUSTER_KEY_FILE" ]; then
+    # We have replica set configuration! Start with replica set options.
     mongo_options+=(
       "--replSet" "$(cat "$REPL_SET_NAME_FILE")"
       "--keyFile" "$CLUSTER_KEY_FILE"
     )
+  else
+    echo "WARNING: Starting in STANDALONE mode (${REPL_SET_NAME_FILE} or ${CLUSTER_KEY_FILE} is missing)."
   fi
 
   exec mongod "${mongo_options[@]}"

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -3,45 +3,280 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+
+# shellcheck disable=SC1091
 . /usr/bin/utilities.sh
 
-# Empty defaults to support [[ -n ... ]] checks with -o nounset.
-: ${SSL_CERTIFICATE:=""}
-: ${SSL_KEY:=""}
+
+DEFAULT_USER="aptible"
+DEFAULT_HOST="$(hostname)"
+DEFAULT_PORT="27017"
+DEFAULT_DATABASE="db"
 
 
-function startMongod() {
-  SUBJ="/C=US/ST=New York/L=New York/O=Example/CN=mongodb.example.com"
-  if [ ! -f "$SSL_DIRECTORY"/mongodb.crt ] && [ ! -f "$SSL_DIRECTORY"/mongodb.key ]; then
-    OPTS="req -nodes -new -x509 -sha256"
-    openssl $OPTS -subj "$SUBJ" -keyout "$SSL_DIRECTORY"/mongodb.key -out "$SSL_DIRECTORY"/mongodb.crt 2> /dev/null
+REPL_SET_NAME_FILE="${DATA_DIRECTORY}/.aptible-replica-set-name"
+CLUSTER_KEY_FILE="${DATA_DIRECTORY}/.aptible-keyfile"
+MEMBER_ID_FILE="${DATA_DIRECTORY}/.aptible-member-id"
+PRE_START_FILE="${DATA_DIRECTORY}/.aptible-on-start"
+
+
+function mongo_init_debug () {
+  # shellcheck disable=2086
+  if [[ -n "${ENABLE_DEBUG:-""}" ]]; then
+    set -o xtrace
   fi
-
-  cat "$SSL_DIRECTORY/mongodb.key" "$SSL_DIRECTORY/mongodb.crt" > "$SSL_DIRECTORY/mongodb.pem"
-  exec mongod --dbpath "$DATA_DIRECTORY" --auth --sslMode "$MONGO_SSL_MODE" --sslPEMKeyFile "$SSL_DIRECTORY/mongodb.pem"
 }
 
-dump_directory="mongodump"
+
+function mongo_environment_minimal () {
+  # shellcheck disable=2086
+  {
+    : ${SSL_CERTIFICATE:=""}
+    : ${SSL_KEY:=""}
+    : ${PORT:="$DEFAULT_PORT"}
+  }
+}
 
 
-if [[ "$#" -eq 0 ]]; then
-  startMongod
+function mongo_environment_full () {
+  mongo_environment_minimal
 
-elif [[ "$1" == "--initialize" ]]; then
+  # Database defaults
+
+  # shellcheck disable=2086
+  {
+    : ${USERNAME:="$DEFAULT_USER"}
+    : ${DATABASE:="$DEFAULT_DATABASE"}
+  }
+
+  # Clustering defaults
+
+  EXPOSE_PORT_PTR="EXPOSE_PORT_${PORT}"
+  # shellcheck disable=2086
+  {
+    : ${EXPOSE_HOST:="$DEFAULT_HOST"}
+  }
+
+  # Set !EXPOSE_PORT_PTR to a default value of PORT if unset. We can't
+  # use ${!EXPOSE_PORT_PTR:=""} because it doesn't work for indirect
+  # references.
+  local canary="VAR_NOT_SET"
+  if [[ "${!EXPOSE_PORT_PTR:-"$canary"}" = "$canary" ]]; then
+    eval "${EXPOSE_PORT_PTR}=${PORT}"
+  fi
+
+  # Check that variables that do not accept defaults are properly set
+  # in the environment.
+  # shellcheck disable=2086
+  {
+    : ${PASSPHRASE:?"PASSPHRASE must be set in the environment"}
+    : ${CLUSTER_KEY:?"CLUSTER_KEY must be set in the environment"}
+  }
+}
+
+
+
+function mongo_initialize_certs () {
   mkdir -p "$SSL_DIRECTORY"
 
   if [ -n "$SSL_CERTIFICATE" ] && [ -n "$SSL_KEY" ]; then
     echo "$SSL_CERTIFICATE" > "$SSL_DIRECTORY"/mongodb.crt
     echo "$SSL_KEY" > "$SSL_DIRECTORY"/mongodb.key
+  else
+    echo "No certs found - autogenerating"
+    SUBJ="/C=US/ST=New York/L=New York/O=Example/CN=mongodb.example.com"
+    OPTS="req -nodes -new -x509 -sha256"
+    # shellcheck disable=2086
+    openssl $OPTS -subj "$SUBJ" -keyout "$SSL_DIRECTORY"/mongodb.key -out "$SSL_DIRECTORY"/mongodb.crt 2> /dev/null
   fi
 
-  PID_PATH=/tmp/mongod.pid
-  mongod --dbpath "$DATA_DIRECTORY" --fork --logpath /dev/null --pidfilepath "$PID_PATH"
-  mongo db --eval "db.createUser({\"user\":\"${USERNAME:-aptible}\",\"pwd\":\"$PASSPHRASE\",\"roles\":[\"dbOwner\"]}, {\"w\":1,\"j\":true})"
+  cat "$SSL_DIRECTORY/mongodb.key" "$SSL_DIRECTORY/mongodb.crt" > "$SSL_DIRECTORY/mongodb.pem"
+}
 
-  kill $(cat $PID_PATH)
-  # wait for lock file to be released
+
+function startMongod () {
+  # TODO - Check if the replica set name exists and if not, we need to call rs initiate... (for migration)
+  # (or just start as standalone)
+  REPL_SET_NAME="$(cat "$REPL_SET_NAME_FILE")"
+
+  # Run the "PRE_START_FILE" if provided
+  if [ -f "$PRE_START_FILE" ]; then
+    "$PRE_START_FILE"
+  fi
+
+  exec mongod \
+    --dbpath "$DATA_DIRECTORY" --port "$PORT"  \
+    --sslMode "$MONGO_SSL_MODE" --sslPEMKeyFile "$SSL_DIRECTORY/mongodb.pem" \
+    --replSet "$REPL_SET_NAME" \
+    --keyFile "$CLUSTER_KEY_FILE" \
+    --auth
+}
+
+dump_directory="mongodump"
+
+# If requested, enable debug before anything.
+mongo_init_debug
+
+if [[ "$#" -eq 0 ]]; then
+  mongo_environment_minimal
+  mongo_initialize_certs
+  startMongod
+
+elif [[ "$1" == "--initialize" ]]; then
+  mongo_environment_full
+
+  # Auto-generate replica set name. We randomize this to ensure multiple MongoDB servers have a different
+  # replica set name (as recommended by MongoDB).
+  REPL_SET_NAME="rs$(pwgen -s 12)"
+  echo "$REPL_SET_NAME" > "$REPL_SET_NAME_FILE"
+
+  # Use the connection password for intra-cluster authentication
+  echo "$CLUSTER_KEY" > "$CLUSTER_KEY_FILE"
+  chmod 600 "$CLUSTER_KEY_FILE"
+
+  # Initialize MongoDB
+  PID_PATH=/tmp/mongod.pid
+  LOG_PATH=/tmp/mongod.log
+  trap 'cat "$LOG_PATH"; rm "$LOG_PATH"' EXIT
+
+  # Start MongoDB. We're only going to connect locally here; we don't enable auth or SSL.
+  mongod --dbpath "$DATA_DIRECTORY" --port "$PORT" --fork --logpath "$LOG_PATH" --pidfilepath "$PID_PATH" --replSet "$REPL_SET_NAME"
+
+  mongo_options="--port $PORT"
+
+  # Initialize replica set configuration using the host we were provided. Since we're using --initialize,
+  # we'll force the host _id to 0 (we're guaranteed that --initialize only runs once per replica set).
+  # shellcheck disable=2086
+  mongo $mongo_options --eval "rs.initiate({_id: \"$REPL_SET_NAME\", members: [{_id: 0, host: \"${EXPOSE_HOST}:${!EXPOSE_PORT_PTR}\"}]})['ok'] || quit(1)"
+
+  # Wait until MongoDB node becomes primary
+  # shellcheck disable=2086
+  until mongo $mongo_options --quiet --eval 'quit(db.isMaster()["ismaster"] ? 0 : 1)'; do
+    echo "Waiting until new MongoDB instance becomes primary"
+    sleep 1
+  done
+
+  # Create users using the connection URL that was provided
+  # shellcheck disable=2086
+  {
+    mongo $mongo_options db --eval "db.createUser({\"user\":\"${USERNAME}\",\"pwd\":\"${PASSPHRASE}\",\"roles\":[\"dbOwner\"]}, {\"w\":1,\"j\":true})"
+    mongo $mongo_options admin --eval "db.createUser({\"user\":\"${USERNAME}\",\"pwd\":\"${PASSPHRASE}\",\"roles\":[\"clusterAdmin\", \"root\"]}, {\"w\":1,\"j\":true})"
+  }
+
+  # Terminate MongoDB and wait for it to exit
+  kill "$(cat "$PID_PATH")"
   while [ -s "$DATA_DIRECTORY"/mongod.lock ]; do sleep 0.1; done
+
+elif [[ "$1" == "--initialize-from" ]]; then
+  if [[ "$#" -lt 2 ]]; then
+    echo "docker run -it aptible/mongodb --initialize-from mongodb://..."
+    exit 1
+  fi
+
+  # We'll need users, passwords, certificates, cluster key, etc. here. They should all come from the environment.
+  mongo_environment_full
+
+  # We have no guarantee that whatever is in FROM_URL is actually the primary, so we have to actually query the primary.
+  # Obviously, this is racy. If there are changes happening on the cluster while we work, we might end up sending cluster
+  # commands to the wrong node. There isn't much we can do about it besides not provisioning multiple MongoDB nodes at the
+  # same time or during an outage.
+  FROM_URL="$2"
+  parse_url "$FROM_URL"
+
+  # Now, get the *actual* primary from that URL
+  # shellcheck disable=2154 disable=2086
+  PRIMARY_HOST_PORT="$(mongo $mongo_options admin --quiet "/mongo-scripts/secondary-find-primary.js" | grep 'PRIMARY HOST PORT:' | sed 's/PRIMARY HOST PORT://g')"
+
+  # Reconstruct primary URL using the credentials we were provided.
+  # TODO - Consider using system and keyfile creds?
+  # shellcheck disable=2154
+  PRIMARY_URL="mongodb://${username}:${password}@${PRIMARY_HOST_PORT}/admin?ssl=true&x-sslVerify=false"
+
+  parse_url "$PRIMARY_URL"
+  # shellcheck disable=2154
+  {
+    PRIMARY_OPTIONS="$mongo_options"
+  }
+
+  # Create key file using cluster key that was provided in the environment.
+  echo "$CLUSTER_KEY" > "$CLUSTER_KEY_FILE"
+  chmod 600 "$CLUSTER_KEY_FILE"
+
+  # Get the replica set name from the primary, and store it for future restarts. Unfortunately, MongoDB logs
+  # things like SSL errors to stdout, so we can't really just get the output of db.runCommand and expect that
+  # to match out replica set name.
+  # shellcheck disable=2154 disable=2086
+  REPL_SET_NAME="$(mongo $PRIMARY_OPTIONS admin --quiet "/mongo-scripts/secondary-get-replica-set-name.js" | grep 'REPLICA SET NAME:' | sed 's/REPLICA SET NAME://g')"
+  echo "$REPL_SET_NAME" > "$REPL_SET_NAME_FILE"
+
+  # Autogenerate a random member ID. This makes it easier for us to update our votes and priority later on,
+  # and also happens to be required for MongoDB 2.6. Unfortunately, the member ID needs to be a rather small
+  # number. We pick one at random, but on the off chance that we pick the same one twice, the commands below
+  # will fail (and exit with an error), and the `--initialize-from` operation needs to be restarted.
+  # TODO - We can use a Mongo script to generate a safe one for us.
+  MEMBER_ID="$(randint_8)"
+  echo "$MEMBER_ID" > "$MEMBER_ID_FILE"
+
+  # Start our local MongoDB to kickstart replication. Since we have SSL either set to requireSSL or preferSSL,
+  # the slave needs to have SSL enabled when it comes up. This operation might take a while (MongoDB will rsync data
+  # over from the slave), so we enable auth to ensure there is no unauthorized access to the replica as it comes up
+  # (which means we won't be able to log in until the users DB is replicated).
+  PID_PATH=/tmp/mongod.pid
+  LOG_PATH=/tmp/mongod.log
+  trap 'cat "$LOG_PATH"; rm "$LOG_PATH"' EXIT
+
+  mongo_initialize_certs
+  mongod --dbpath "$DATA_DIRECTORY" --port "$PORT" --fork --logpath "$LOG_PATH" --pidfilepath "$PID_PATH" --replSet "$REPL_SET_NAME" --keyFile "$CLUSTER_KEY_FILE" --sslMode "$MONGO_SSL_MODE" --sslPEMKeyFile "$SSL_DIRECTORY/mongodb.pem" --auth
+
+  # Initate replication, from the primary Point it to the new replica we just launched.
+  # shellcheck disable=2086
+  mongo $PRIMARY_OPTIONS admin --quiet --eval "rs.add({host: \"${EXPOSE_HOST}:${!EXPOSE_PORT_PTR}\", votes: 0, priority: 0, _id: ${MEMBER_ID}})['ok'] || quit(1)"
+
+  # Determine the URL this replica will acquire (and check its validity by parsing it - we'll use it later anyway)
+  SECONDARY_URL="mongodb://${USERNAME}:${PASSPHRASE}@${EXPOSE_HOST}:${!EXPOSE_PORT_PTR}/admin?ssl=true&x-sslVerify=false"
+  parse_url "$SECONDARY_URL"
+
+  # Let's tell our Mongo that it should update itself to become a voting member when it comes back up
+  cat > "$PRE_START_FILE" <<EOM
+#!/bin/bash
+/mongo-scripts/reconfig.sh "$PRIMARY_URL" "$SECONDARY_URL" &
+EOM
+  chmod +x "$PRE_START_FILE"
+
+  # Wait until we actually join the cluster.
+  # shellcheck disable=2154 disable=2086
+  until mongo $mongo_options "$database" --quiet --eval 'quit((db.isMaster()["ismaster"] || db.isMaster()["secondary"]) ? 0 : 1)'; do
+    echo "Waiting until new MongoDB instance becomes primary or secondary"
+    sleep 1
+  done
+
+  # Initialization is done, terminate MongoDB
+  echo "Initial sync complete. Terminating MongoDB"
+  kill "$(cat "$PID_PATH")"
+  while [ -s "$DATA_DIRECTORY"/mongod.lock ]; do sleep 0.1; done
+
+elif [[ "$1" == "--discover" ]]; then
+  mongo_environment_minimal
+
+  cat <<EOM
+{
+  "exposed_ports": [
+    ${PORT}
+  ],
+  "suggested_configuration": {
+    "CLUSTER_KEY": "$(pwgen -s 64)",
+    "PASSPHRASE": "$(pwgen -s 32)"
+  }
+}
+EOM
+
+elif [[ "$1" == "--connection-url" ]]; then
+  mongo_environment_full
+  cat <<EOM
+{
+  "url": "mongodb://${USERNAME}:${PASSPHRASE}@${EXPOSE_HOST}:${!EXPOSE_PORT_PTR}/${DATABASE}?ssl=true"
+}
+EOM
 
 elif [[ "$1" == "--client" ]]; then
   if [[ "$#" -lt 2 ]]; then
@@ -51,6 +286,7 @@ elif [[ "$1" == "--client" ]]; then
   parse_url "$2"
   shift
   shift
+  # shellcheck disable=2154 disable=2086
   exec mongo $mongo_options "$database" "$@"
 
 elif [[ "$1" == "--dump" ]]; then
@@ -62,6 +298,8 @@ elif [[ "$1" == "--dump" ]]; then
   # Can't dump the whole database to stdout in a straightforward way. Instead,
   # dump to a directory and then tar the directory and print the tar to stdout.
   parse_url "$2"
+
+  # shellcheck disable=2154 disable=2086
   mongodump $mongo_options --db="$database" --out="/tmp/${dump_directory}" > /dev/null && tar cf - -C /tmp/ "$dump_directory"
 
 elif [[ "$1" == "--restore" ]]; then
@@ -71,6 +309,7 @@ elif [[ "$1" == "--restore" ]]; then
   fi
   tar xf - -C /tmp/
   parse_url "$2"
+  # shellcheck disable=2154 disable=2086
   mongorestore $mongo_options --db="$database" "/tmp/${dump_directory}/${database}"
 
 elif [[ "$1" == "--readonly" ]]; then
@@ -86,9 +325,10 @@ elif [[ "$1" == "--readonly" ]]; then
   #
   # With all of that said, leaving off read-only mode for now.
   echo "This image does not support read-only mode. Starting database normally."
+  mongo_environment_minimal
+  mongo_initialize_certs
   startMongod
 else
   echo "Unrecognized command: $1"
   exit 1
-
 fi

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -180,6 +180,13 @@ elif [[ "$1" == "--initialize" ]]; then
 
   mongo_options="--port $PORT"
 
+  # Wait until MongoDB comes online
+  # shellcheck disable=2086
+  until mongo $mongo_options --quiet --eval 'quit(0)'; do
+    echo "Waiting until MongoDB comes online"
+    sleep 2
+  done
+
   # Initialize replica set configuration using the host we were provided. Since we're using --initialize,
   # we'll force the host _id to 0 (we're guaranteed that --initialize only runs once per replica set).
   # shellcheck disable=2086

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -180,7 +180,7 @@ elif [[ "$1" == "--initialize" ]]; then
   # shellcheck disable=2086
   until mongo $mongo_options --quiet --eval 'quit(db.isMaster()["ismaster"] ? 0 : 1)'; do
     echo "Waiting until new MongoDB instance becomes primary"
-    sleep 1
+    sleep 2
   done
 
   # Create users using the connection URL that was provided
@@ -276,7 +276,7 @@ EOM
   # shellcheck disable=2154 disable=2086
   until mongo $mongo_options "$database" --quiet --eval 'quit((db.isMaster()["ismaster"] || db.isMaster()["secondary"]) ? 0 : 1)'; do
     echo "Waiting until new MongoDB instance becomes primary or secondary"
-    sleep 1
+    sleep 2
   done
 
   # Initialization is done, terminate MongoDB

--- a/bin/utilities.sh
+++ b/bin/utilities.sh
@@ -4,3 +4,7 @@ parse_url() {
   mongo_params="$(parse_mongo_url.py "$1")"
   eval "$mongo_params"
 }
+
+randint_8() {
+  openssl rand 1 | od -DAn | tr -d '[:space:]'
+}

--- a/templates/mongo-scripts/primary-add-nonvoting-secondary.js
+++ b/templates/mongo-scripts/primary-add-nonvoting-secondary.js
@@ -1,0 +1,12 @@
+// Expecting secondary_member_id and secondary_host to be passed in
+var ret = rs.add({
+  _id: secondary_member_id,
+  host: secondary_host,
+  votes: 0,
+  priority: 0
+})
+
+if (!ret["ok"]) {
+  printjson(ret);
+  quit(1);
+}

--- a/templates/mongo-scripts/primary-add-user-permissions.js
+++ b/templates/mongo-scripts/primary-add-user-permissions.js
@@ -1,0 +1,11 @@
+// Expecting user_name, user_passphrase and user_db as inputs
+
+var writeConcern = {"w": 1, "j": true};
+
+db.getSiblingDB(user_db).createUser({
+  "user": user_name, "pwd": user_passphrase, "roles": ["dbOwner"]
+}, writeConcern);
+
+db.getSiblingDB("admin").createUser({
+  "user": user_name, "pwd": user_passphrase, "roles": ["clusterAdmin", "root"]
+}, writeConcern);

--- a/templates/mongo-scripts/primary-enable-secondary.js
+++ b/templates/mongo-scripts/primary-enable-secondary.js
@@ -1,0 +1,22 @@
+// Expect secondary_name to be set as a variable.
+// Unfortunately, this is racy, but it's the best the
+// MongoDB docs have to offer :(
+
+var conf = rs.conf();
+
+var member;
+for (var i = 0; i < conf["members"].length; i++) {
+  member = conf["members"][i];
+  if (member.host === secondary_name ) {
+    member.priority = 1;
+    member.votes = 1;
+  }
+}
+
+var ret = rs.reconfig(conf);
+
+if (ret["ok"] === 1) {
+  print("SUCCESS");
+} else {
+  quit(1);
+}

--- a/templates/mongo-scripts/primary-initiate-replica-set.js
+++ b/templates/mongo-scripts/primary-initiate-replica-set.js
@@ -1,0 +1,17 @@
+// Expecting:
+// replica_set_name
+// primary_member_id
+// primary_host
+
+var ret = rs.initiate({
+  _id: replica_set_name,
+  members: [{
+    _id: primary_member_id,
+    host: primary_host
+  }]
+});
+
+if (!ret["ok"]) {
+  printjson(ret);
+  quit(1);
+}

--- a/templates/mongo-scripts/primary-test-member-id.js
+++ b/templates/mongo-scripts/primary-test-member-id.js
@@ -1,0 +1,13 @@
+// We expect member_id to be an input that is to be tested.
+
+var conf = rs.conf();
+var member;
+
+for (var i = 0; i < conf["members"].length; i++) {
+  member = conf["members"][i];
+  if (member._id === member_id) {
+    print("Member ID is in use");
+    printjson(member);
+    quit(1);
+  }
+}

--- a/templates/mongo-scripts/reconfig.sh
+++ b/templates/mongo-scripts/reconfig.sh
@@ -30,5 +30,7 @@ done
 SECONDARY_NAME="$(find_secondary_name )"
 
 run-database.sh --client "$PRIMARY_URL" --eval "var secondary_name='$SECONDARY_NAME'" "/mongo-scripts/primary-enable-secondary.js"
-
 echo "Reconfigured primary!"
+
+mv "$0" "${0}.$(date --iso-8601=seconds).bak"
+echo "Moved this file out"

--- a/templates/mongo-scripts/reconfig.sh
+++ b/templates/mongo-scripts/reconfig.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script expects to be passed:
+# $1: primary URL.
+# $2: secondary URL.
+
+# It'll update the replication configuration on the primary
+# by granting votes = 1 and priority = 1 to the secondary
+# once the secondary is up.
+
+# This is a best effort. If the primary happens to have changed
+# by now, this will fail.
+
+PRIMARY_URL="$1"
+SECONDARY_URL="$2"
+
+# TODO - Path and name of the script
+function find_secondary_name () {
+  run-database.sh --client "$SECONDARY_URL" "/mongo-scripts/secondary-get-name.js"  | grep "SERVER NAME" | sed "s/SERVER NAME://g"
+}
+
+until find_secondary_name ; do
+  sleep 1
+  echo "Waiting for secondary to come online"
+done
+
+SECONDARY_NAME="$(find_secondary_name )"
+
+run-database.sh --client "$PRIMARY_URL" --eval "var secondary_name='$SECONDARY_NAME'" "/mongo-scripts/primary-enable-secondary.js"
+
+echo "Reconfigured primary!"

--- a/templates/mongo-scripts/secondary-find-primary.js
+++ b/templates/mongo-scripts/secondary-find-primary.js
@@ -1,0 +1,16 @@
+var status = rs.status();
+
+var primary = null;
+for (var i = 0; i < status["members"].length; i++) {
+  member = status["members"][i];
+  if (member.stateStr === "PRIMARY" ) {
+    primary = member
+  }
+}
+
+if (!primary) {
+  print("Failed to locate primary!");
+  quit(1);
+} else {
+  print("PRIMARY HOST PORT:" + primary.name);
+}

--- a/templates/mongo-scripts/secondary-find-primary.js
+++ b/templates/mongo-scripts/secondary-find-primary.js
@@ -10,7 +10,8 @@ for (var i = 0; i < status["members"].length; i++) {
 
 if (!primary) {
   print("Failed to locate primary!");
+  printjson(status);
   quit(1);
 } else {
-  print("PRIMARY HOST PORT:" + primary.name);
+  print(extract_prefix + primary.name);
 }

--- a/templates/mongo-scripts/secondary-get-name.js
+++ b/templates/mongo-scripts/secondary-get-name.js
@@ -1,0 +1,3 @@
+var conf = rs.isMaster();
+var name = conf["me"];
+print("SERVER NAME:" + conf["me"]);

--- a/templates/mongo-scripts/secondary-get-replica-set-name.js
+++ b/templates/mongo-scripts/secondary-get-replica-set-name.js
@@ -1,0 +1,8 @@
+var status = rs.status();
+
+if (!status["ok"]) {
+  quit(1);
+}
+
+var name = status["set"];
+print("REPLICA SET NAME:" + name);

--- a/templates/mongo-scripts/secondary-get-replica-set-name.js
+++ b/templates/mongo-scripts/secondary-get-replica-set-name.js
@@ -5,4 +5,4 @@ if (!status["ok"]) {
 }
 
 var name = status["set"];
-print("REPLICA SET NAME:" + name);
+print(extract_prefix + name);

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$REGISTRY/$REPOSITORY:$TAG"
+
+R1_CONTAINER="mongodb-r1"
+R1_DATA_CONTAINER="${R1_CONTAINER}-data"
+R1_PORT=27117
+
+R2_CONTAINER="mongodb-r2"
+R2_DATA_CONTAINER="${R2_CONTAINER}-data"
+R2_PORT=27217
+
+R3_CONTAINER="mongodb-r3"
+R3_DATA_CONTAINER="${R3_CONTAINER}-data"
+R3_PORT=27217
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$R1_CONTAINER" "$R1_DATA_CONTAINER" "$R2_CONTAINER" "$R2_DATA_CONTAINER" "$R3_CONTAINER" "$R3_DATA_CONTAINER" || true
+}
+
+trap cleanup EXIT
+cleanup
+
+# Helper script
+READ_SUGGESTED_CONFIG_SCRIPT='
+import sys, json, pipes
+c = json.load(sys.stdin)["suggested_configuration"]
+opts = []
+for k, v in c.items():
+  opts.append("-e")
+  opts.append(pipes.quote("{0}={1}".format(k, v)))
+print "ENV_ARGS=({0})".format(" ".join(opts))
+'
+
+READ_DATABASE_URL_SCRIPT='
+import sys, json
+print json.load(sys.stdin)["url"] + "&x-sslVerify=false",
+'
+
+
+USER=testuser
+PASSPHRASE=testpass
+DATABASE=db  # TODO: test with custom DB
+
+# ENV_ARGS will represent the configuration that Sweetness would be passing.
+# It's the suggested_configuration obtained from --discover, to which we add
+# USERNAME, DATABASE, EXPOSE_HOST and EXPOSE_PORT_XXXXX.
+# We're also throwing in ENABLE_DEBUG, because this is a test.
+
+echo "Importing suggested configuration"
+eval "$(docker run -i "$IMG" --discover | python -c "$READ_SUGGESTED_CONFIG_SCRIPT")"
+
+ENV_ARGS+=("-e" "USERNAME=$USER" "-e" "PASSPHRASE=$PASSPHRASE" "-e" "DATABASE=$DATABASE" -e "ENABLE_DEBUG=1")
+
+R1_ENV_ARGS+=(
+  "${ENV_ARGS[@]}"
+  "-e" "PORT=${R1_PORT}"
+  "-e" "EXPOSE_HOST=$R1_CONTAINER" "-e" "EXPOSE_PORT_${R1_PORT}=${R1_PORT}"
+)
+
+R2_ENV_ARGS+=(
+  "${ENV_ARGS[@]}"
+  "-e" "PORT=${R2_PORT}"
+  "-e" "EXPOSE_HOST=$R2_CONTAINER" "-e" "EXPOSE_PORT_${R2_PORT}=${R2_PORT}"
+)
+
+R3_ENV_ARGS+=(
+  "${ENV_ARGS[@]}"
+  "-e" "PORT=${R3_PORT}"
+  "-e" "EXPOSE_HOST=$R3_CONTAINER" "-e" "EXPOSE_PORT_${R3_PORT}=${R3_PORT}"
+)
+
+echo "Initializing data containers"
+
+for data_container in  "$R1_DATA_CONTAINER" "$R2_DATA_CONTAINER" "$R3_DATA_CONTAINER"; do
+  docker create --name "$data_container" "$IMG"
+done
+
+# Now: a hackish hack. We need to get the IP address of our containers so we can add them to
+# --add-host, but there's a chicken and egg problem:
+# + We can only set --add-host at startup.
+# + We can only get a container's IP address after it started.
+# + We have > 1 containers that need to know each other's IP address.
+# So, since we know recent versions of Docker reuse IP addresses, we'll launch as many containers
+# as we need, and get their IP addresses. We expect the same IP addresses will be reused. Ugh.
+
+echo "Guessing IPs"
+
+for container in "$R1_CONTAINER" "$R2_CONTAINER" "$R3_CONTAINER"; do
+  docker run -d --name "$container" "quay.io/aptible/debian:wheezy" sh -c 'hostname -I && exec sleep 10000'
+done
+
+# xargs trims whitespace for us here
+R1_IP="$(docker logs "$R1_CONTAINER" | xargs)"
+R2_IP="$(docker logs "$R2_CONTAINER" | xargs)"
+R3_IP="$(docker logs "$R3_CONTAINER" | xargs)"
+docker kill "$R1_CONTAINER" "$R2_CONTAINER" "$R3_CONTAINER"
+docker rm   "$R1_CONTAINER" "$R2_CONTAINER" "$R3_CONTAINER"
+
+# This is here to emulate functional DNS.
+IP_ARGS=(
+  "--add-host" "${R1_CONTAINER}:${R1_IP}"
+  "--add-host" "${R2_CONTAINER}:${R2_IP}"
+  "--add-host" "${R3_CONTAINER}:${R3_IP}"
+)
+
+function check_ip () {
+  local container="$1"
+  local expected_ip="$2"
+  local real_ip
+  real_ip="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$container")"
+
+  if [[ "$expected_ip" != "$real_ip" ]]; then
+    echo "${container} IP is unexpected: expected ${expected_ip}, got ${real_ip}"
+    exit 1
+  fi
+}
+
+
+echo "Initializing first member"
+
+
+docker run -i --rm \
+  "${R1_ENV_ARGS[@]}" \
+  "${IP_ARGS[@]}" \
+  --volumes-from "$R1_DATA_CONTAINER" \
+  "$IMG" --initialize
+
+docker run -d --name="$R1_CONTAINER" \
+  "${R1_ENV_ARGS[@]}" \
+  "${IP_ARGS[@]}" \
+  --volumes-from "$R1_DATA_CONTAINER" \
+  "$IMG"
+
+check_ip "$R1_CONTAINER" "$R1_IP"
+
+
+# Wait until the first node becomes the master
+R1_URL="$(docker run -i "${R1_ENV_ARGS[@]}" "$IMG" --connection-url | python -c "$READ_DATABASE_URL_SCRIPT")"
+until docker run --rm -i "${IP_ARGS[@]}" "$IMG" --client "$R1_URL" --quiet --eval 'quit(db.isMaster()["ismaster"] ? 0 : 1)'; do sleep 1; done
+
+
+echo "Initializing second member"
+R2_URL="$(docker run -i "${R2_ENV_ARGS[@]}" "$IMG" --connection-url | python -c "$READ_DATABASE_URL_SCRIPT")"
+R2_ADMIN_URL="$(docker run -i "${R2_ENV_ARGS[@]}" -e "DATABASE=admin" "$IMG" --connection-url | python -c "$READ_DATABASE_URL_SCRIPT")"
+
+docker run -i --rm \
+  "${R2_ENV_ARGS[@]}" \
+  "${IP_ARGS[@]}" \
+  --volumes-from "$R2_DATA_CONTAINER" \
+  "$IMG" --initialize-from "$R1_URL"
+
+# Now, simulate some time before restarting R2. We want to make sure the primary does not 
+# step down during this time.
+
+echo "Simulating ${R2_CONTAINER} start delay"
+delay=20
+step=4
+for time_left in $(seq "$delay" "-${step}" 1); do
+  echo "${time_left} seconds left..."
+  sleep "$step"
+done
+
+
+if docker logs "${R1_CONTAINER}" | grep "relinquishing primary"; then
+  echo "FAIL: ${R1_CONTAINER} stepped down:"
+  docker logs "${R1_CONTAINER}"
+  exit 1
+fi
+
+docker run -d --name "$R2_CONTAINER" \
+  "${R2_ENV_ARGS[@]}" \
+  "${ENV_ARGS[@]}" \
+  "${IP_ARGS[@]}" \
+  --volumes-from "$R2_DATA_CONTAINER" \
+  "$IMG"
+
+check_ip "$R2_CONTAINER" "$R2_IP"
+
+# TODO: Run some more tests
+
+until docker run --rm -i "${IP_ARGS[@]}" "$IMG" --client "$R2_ADMIN_URL" --quiet --eval 'quit(db.isMaster()["secondary"] ? 0 : 1)'; do sleep 1; done
+
+
+echo "Initializing third member from second"
+# This will only pass if the initialization script is smart enough to resolve the real primary and not rely on --initialize-from
+docker run -i --rm \
+  "${R3_ENV_ARGS[@]}" \
+  "${IP_ARGS[@]}" \
+  --volumes-from "$R3_DATA_CONTAINER" \
+  "$IMG" --initialize-from "$R2_URL"
+
+docker run -d --name="$R3_CONTAINER" \
+  "${R3_ENV_ARGS[@]}" \
+  "${IP_ARGS[@]}" \
+  --volumes-from "$R3_DATA_CONTAINER" \
+  "$IMG"
+
+check_ip "$R3_CONTAINER" "$R3_IP"
+
+R3_ADMIN_URL="$(docker run -i "${R3_ENV_ARGS[@]}" -e "DATABASE=admin" "$IMG" --connection-url | python -c "$READ_DATABASE_URL_SCRIPT")"
+until docker run --rm -i "${IP_ARGS[@]}" "$IMG" --client "$R3_ADMIN_URL" --quiet --eval 'quit(db.isMaster()["secondary"] ? 0 : 1)'; do sleep 1; done
+
+# And now, check that our cluster looks healthy!
+echo "Cluster configuration:"
+docker run --rm -i "${IP_ARGS[@]}" "$IMG" --client "$R2_ADMIN_URL" --quiet --eval 'rs.conf()'
+
+echo "Cluster status:"
+docker run --rm -i "${IP_ARGS[@]}" "$IMG" --client "$R2_ADMIN_URL" --quiet --eval 'rs.status()'
+
+echo "Checking all members have appropriate voting and priority configuration"
+docker run --rm -i "${IP_ARGS[@]}" "$IMG" --client "$R2_ADMIN_URL" "/tmp/test/assert-votes.js"
+
+echo "Test OK!"

--- a/test.sh
+++ b/test.sh
@@ -150,7 +150,7 @@ check_ip "$R1_CONTAINER" "$R1_IP"
 
 # Wait until the first node becomes the master
 R1_URL="$(docker run -i "${R1_ENV_ARGS[@]}" "$IMG" --connection-url | python -c "$READ_DATABASE_URL_SCRIPT")"
-until docker run --rm -i "${IP_ARGS[@]}" "$IMG" --client "$R1_URL" --quiet --eval 'quit(db.isMaster()["ismaster"] ? 0 : 1)'; do sleep 1; done
+until docker run --rm -i "${IP_ARGS[@]}" "$IMG" --client "$R1_URL" --quiet --eval 'quit(db.isMaster()["ismaster"] ? 0 : 1)'; do sleep 2; done
 
 
 echo "Initializing second member"
@@ -190,7 +190,7 @@ docker run -d --name "$R2_CONTAINER" \
 
 check_ip "$R2_CONTAINER" "$R2_IP"
 
-# TODO: Run some more tests
+until docker run --rm -i "${IP_ARGS[@]}" "$IMG" --client "$R2_ADMIN_URL" --quiet --eval 'quit(db.isMaster()["secondary"] ? 0 : 1)'; do sleep 2; done
 
 until docker run --rm -i "${IP_ARGS[@]}" "$IMG" --client "$R2_ADMIN_URL" --quiet --eval 'quit(db.isMaster()["secondary"] ? 0 : 1)'; do sleep 1; done
 
@@ -212,7 +212,7 @@ docker run -d --name="$R3_CONTAINER" \
 check_ip "$R3_CONTAINER" "$R3_IP"
 
 R3_ADMIN_URL="$(docker run -i "${R3_ENV_ARGS[@]}" -e "DATABASE=admin" "$IMG" --connection-url | python -c "$READ_DATABASE_URL_SCRIPT")"
-until docker run --rm -i "${IP_ARGS[@]}" "$IMG" --client "$R3_ADMIN_URL" --quiet --eval 'quit(db.isMaster()["secondary"] ? 0 : 1)'; do sleep 1; done
+until docker run --rm -i "${IP_ARGS[@]}" "$IMG" --client "$R3_ADMIN_URL" --quiet --eval 'quit(db.isMaster()["secondary"] ? 0 : 1)'; do sleep 2; done
 
 # And now, check that our cluster looks healthy!
 echo "Cluster configuration:"

--- a/test/assert-votes.js
+++ b/test/assert-votes.js
@@ -3,9 +3,17 @@ var ret = 0;
 
 for (var i = 0; i < conf["members"].length; i++) {
   member = conf["members"][i];
-  if (member.priority !== 1 || member.votes !==1) {
+  // In Mongo 2.6, priority and votes aren't returned when
+  // they are default (1), so we check for undefined as well.
+  if (
+      (member.priority !== 1 && typeof member.priority !== 'undefined') ||
+      (member.votes !== 1 && typeof member.votes !== 'undefined')
+  ) {
     print("MISCONFIGURED: " + member.host);
+    printjson(member);
     ret = 1;
+  } else {
+    print("OK: " + member.host);
   }
 }
 

--- a/test/assert-votes.js
+++ b/test/assert-votes.js
@@ -1,0 +1,12 @@
+var conf = rs.conf();
+var ret = 0;
+
+for (var i = 0; i < conf["members"].length; i++) {
+  member = conf["members"][i];
+  if (member.priority !== 1 || member.votes !==1) {
+    print("MISCONFIGURED: " + member.host);
+    ret = 1;
+  }
+}
+
+quit(ret);

--- a/test/mongodb-all.bats
+++ b/test/mongodb-all.bats
@@ -30,3 +30,12 @@ source "${BATS_TEST_DIRNAME}/test_helpers.sh"
 @test "It should pass parse_mongo_url.py unit tests" {
   python -B -m doctest /usr/bin/parse_mongo_url.py
 }
+
+@test "--discover and --connection-url should return valid JSON" {
+  run-database.sh --discover | python -c 'import sys, json; json.load(sys.stdin)'
+  CLUSTER_KEY=test PASSPHRASE=test run-database.sh --connection-url | python -c 'import sys, json; json.load(sys.stdin)'
+}
+
+@test "--connection-url should return a valid connection URL" {
+  # TODO
+}

--- a/test/mongodb-all.bats
+++ b/test/mongodb-all.bats
@@ -57,3 +57,13 @@ source "${BATS_TEST_DIRNAME}/test_helpers.sh"
   [ "$status" -eq 1 ]
   echo "$output" | grep "CLUSTER_KEY must be set"
 }
+
+@test "It should start standalone without a key file" {
+  wait_for_mongodb
+  grep "STANDALONE" "$BATS_TEST_DIRNAME/mongodb.log"
+}
+
+@test "It should start standalone without a replica set name file" {
+  wait_for_mongodb
+  grep "STANDALONE" "$BATS_TEST_DIRNAME/mongodb.log"
+}

--- a/test/mongodb-all.bats
+++ b/test/mongodb-all.bats
@@ -2,7 +2,6 @@
 
 source "${BATS_TEST_DIRNAME}/test_helpers.sh"
 
-
 @test "It should accept SSL connections" {
   initialize_mongodb
   wait_for_mongodb
@@ -39,3 +38,15 @@ source "${BATS_TEST_DIRNAME}/test_helpers.sh"
 @test "--connection-url should return a valid connection URL" {
   # TODO
 }
+
+@test "It should allow --initialize without CLUSTER_KEY" {
+  USERNAME="$DATABASE_USER" PASSPHRASE="$DATABASE_PASSWORD" DATABASE=db run run-database.sh --initialize
+  [ "$status" -eq 0 ]
+  echo "$output" | grep "WARNING: CLUSTER_KEY is unset"
+}
+
+@test "It should not allow --initialize-from without CLUSTER_KEY" {
+  USERNAME="$DATABASE_USER" PASSPHRASE="$DATABASE_PASSWORD" DATABASE=db run run-database.sh --initialize-from "mongodb://dummy:dummy@dummy@dummy/dummy"
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "CLUSTER_KEY must be set"
+ }

--- a/test/mongodb-all.bats
+++ b/test/mongodb-all.bats
@@ -16,8 +16,11 @@ source "${BATS_TEST_DIRNAME}/test_helpers.sh"
   initialize_mongodb
   wait_for_mongodb
 
+  wait_for_master "$DATABASE_URL"
   run-database.sh --client "$DATABASE_URL" --eval "db.test.insert({\"$test_data\": null})"
+
   run-database.sh --dump "$DATABASE_URL" > "$BATS_TEST_DIRNAME/backup"
+
   run-database.sh --client "$DATABASE_URL" --eval "db.dropDatabase()"
   run-database.sh --restore "$DATABASE_URL" < "$BATS_TEST_DIRNAME/backup"
 

--- a/test/test_helpers.sh
+++ b/test/test_helpers.sh
@@ -41,7 +41,7 @@ wait_for_mongodb() {
 
   # Transition to PRIMARY shows in the log before the node is actually able to accept writes,
   # so we sleep a little bit after seeing it.
-  timeout 4 sh -c "while  ! grep 'PRIMARY' '$BATS_TEST_DIRNAME/mongodb.log' ; do sleep 0.1; done"
+  timeout 20 sh -c "while  ! grep 'PRIMARY' '$BATS_TEST_DIRNAME/mongodb.log' ; do sleep 0.1; done"
   sleep 2
 }
 

--- a/test/test_helpers.sh
+++ b/test/test_helpers.sh
@@ -18,6 +18,9 @@ setup() {
 }
 
 teardown() {
+  # Dump log, if any (facilitates troubleshooting)
+  cat "$BATS_TEST_DIRNAME/mongodb.log" || true
+  # Actually teardown
   export DATA_DIRECTORY="$OLD_DATA_DIRECTORY"
   export SSL_DIRECTORY="$OLD_SSL_DIRECTORY"
   unset OLD_DATA_DIRECTORY
@@ -59,3 +62,13 @@ wait_for_mongodb() {
   done
 }
 
+wait_for_master() {
+  local database_url="$1"
+  for i in $(seq 10 -1 0); do
+    if run-database.sh --client "$database_url" --eval 'quit(db.isMaster()["ismaster"] ? 0 : 1)'; then
+      break
+    fi
+    echo "Waiting until MongoDB becomes master"
+    sleep 2
+  done
+}

--- a/test/test_helpers.sh
+++ b/test/test_helpers.sh
@@ -8,6 +8,7 @@ setup() {
   export QUERY="printjson(db.getCollectionNames())"
   export DATABASE_USER="aptible"
   export DATABASE_PASSWORD="password12345"
+  export DATABASE_CLUSTER_KEY="key1234"
   export DATABASE_URL_NO_SSL="mongodb://$DATABASE_USER:$DATABASE_PASSWORD@localhost/db"
   export DATABASE_URL="$DATABASE_URL_NO_SSL?ssl=true&x-sslVerify=false"
   rm -rf "$DATA_DIRECTORY"
@@ -24,6 +25,7 @@ teardown() {
   unset QUERY
   unset DATABASE_USER
   unset DATABASE_PASSWORD
+  unset DATABASE_CLUSTER_KEY
   unset DATABASE_URL
   PID=$(pgrep mongod) || return 0
   run pkill mongod
@@ -31,11 +33,15 @@ teardown() {
 }
 
 initialize_mongodb() {
-  USERNAME="$DATABASE_USER" PASSPHRASE="$DATABASE_PASSWORD" run-database.sh --initialize
+  USERNAME="$DATABASE_USER" CLUSTER_KEY="$DATABASE_CLUSTER_KEY" PASSPHRASE="$DATABASE_PASSWORD" DATABASE=db run-database.sh --initialize
 }
 
 wait_for_mongodb() {
   run-database.sh > "$BATS_TEST_DIRNAME/mongodb.log" &
-  timeout 4 sh -c "while  ! grep 'waiting for connections' '$BATS_TEST_DIRNAME/mongodb.log' ; do sleep 0.1; done"
+
+  # Transition to PRIMARY shows in the log before the node is actually able to accept writes,
+  # so we sleep a little bit after seeing it.
+  timeout 4 sh -c "while  ! grep 'PRIMARY' '$BATS_TEST_DIRNAME/mongodb.log' ; do sleep 0.1; done"
+  sleep 2
 }
 


### PR DESCRIPTION
This PR adds support for MongoDB **replica sets** (not shards). Here's what changed, "method" by method:

## regular server run ##

If **both** `.aptible-replica-set-name` and `.aptible-keyfile` are present in the data directory, then MongoDB will start in replica set mode.

This makes migration from old containers possible by adding those files and then restarting them (and  then following the instructions from MongoDB to bootstrap a replica set — i.e. run `rs.initiate()`).  However, it does **not** make downgrade possible: if you simply remove those files, the Mongo instance will (probably) fail to start because its data directory has a replica whereas its configuration doesn't.

Second, if there's a file called `.aptible-on-start` in the data directory, it is executed before Mongo is started. You'll see why this is important / useful in a bit.

As a side note, Mongo now accepts a `PORT` environment variable (which mostly helps with testing)

Those changes happened in `startMongod` for the most part.

## `--initialize` ##

First and foremost, this expects to receive `EXPOSE_HOST` and `EXPOSE_PORT_27017` in the environment to work (because MongoDB needs to know about its host and port). Those actually need to work, too. This is provided by https://github.com/aptible/sweetness/pull/527.

Several other changes here:

1. First, this generates a replica set name and writes it to `.aptible-replica-set-name` in the data directory.
2. Second, if `CLUSTER_KEY` is present in the environment, it writes it to `.aptible-key`. Otherwise, it prints out a warning, and auto-generates one. The latter is here for compatibility with v1 stacks that don't support the `--discover` API (see: https://github.com/aptible/sweetness/pull/527): you'd let the master create the `CLUSTER_KEY`, and then copy it into its configuration yourself for clones to initialize from (v1 should support *reading* configurations into the environment).
3. Third, after starting the node, it calls `rs.initiate()` to create a replica set.
4. The `aptible` user is now given `root` and `clusterAdmin` permissions on the `admin` db, which makes it possible to. Should we give that user a separate name? (e.g. root).
5. After the command completes, this prints out the MongoDB logs, which makes it easier to understand / troubleshoot.

## `--initialize-from` ##

Obviously, this is new. Just like `--initialize`, this expects `EXPOSE_HOST` and `EXPOSE_PORT_27017`. It also expects `CLUSTER_KEY` to be provided. 

Unlike `--initialize`, this fails if `CLUSTER_KEY` is missing: it just doesn't make sense to join a cluster that you don't have the key for..!

Here's what this does:

1. It queries the host that was passed in `$2` for the current cluster primary (which may or may not be that node!).
2. It queries that node for the current replica set name (and writes it out to its own `.aptible-replica-set-name` file). It also writes out the `CLUSTER_KEY` to the appropriate file.
3. It auto-generates a random member ID for itself between 0 and 256 (bigger ints don't work). If the member ID appears to be already in use, then it tries another one.
4. It adds itself to the replica set **as a non-voting, non-electable member** (votes = 0, priority = 0).
5. It writes out a file to be executed when the node comes back up (to `.aptible-on-start`). See below.
6. It wait until replication is done catching up, and terminates.

### Start up file ###

About that `.aptible-on-start` file... The reason we provision the member as non-voting and non-electable is because the restart after `--initialize-from` can render the cluster unavailable. Here's why: if it's the first replica you're provisioning (i.e. the second node in total), then the existing primary would step down because it doesn't have a quorum (it can only reach itself, which accounts for 50% of the cluster).

But, odds are you do want a voting replica! 

So, the file written to `.aptible-on-start` (which is the `reconfig.sh` script) will basically update that for you. It's a best-effort thing, though: if it fails, you still get your replica, only you'll have to reconfigure the cluster yourself.

**Note: this won't work if you already have 7 voting members (that's the maximum in MongoDB)**. I haven't tested what happens yet.

### Race conditions ###

Note that **there are several race conditions here** (the master could change after 1., another node could choose the same member ID between 3. and 4.). 

Unfortunately, there just isn't much I can do about that, but it's definitely best to avoid provisioning multiple replicas at the same time (you'd have the same problem if you were doing it manually, though). I've done what I can to minimize them, but they can't be eliminated.


### Why not do all initialization at startup to avoid restarts? ####

An alternative to all of this would be for `--initialize-from` to simply write out a file that kicks off replication at startup, which would avoid the node restarting after having joined the cluster, and thus would obviate the need for starting the node as a nonvoting replica.

There are two reasons I opted not to that:

+ It wouldn't be consistent with other DBs. All things being equal, I prefer to stay consistent, but more importantly, that means that we wouldn't be able to e.g. take advantage of providing the replica-to-be with a snapshot of the parent's disk during `--initialize-from` if we ever built that.
+ The failure scenarios are clearer here, and the worst case silent failure scenario is you get a replica that's non-voting and non-primary, which can trivially be diagnosed and fixed via the Mongo shell.

## `--discover` and `--connection-url` ##

This introduces 2 proposed new API to our DB API, whose goal is to decouple Sweetness and DBs:

+ `--discover` returns the ports exposed by the DB, and a suggested configuration (which is used to generate the `CLUSTER_KEY` and `PASSPHRASE` here). Not sure how useful the ports are. I'm fine with removing them if we'd rather rely on `EXPOSE` instead. 
+ `--connection-url` expects the `EXPOSE_HOST` and `EXPOSE_PORT_...` environment variables to be passed, and returns a connection URL for this DB.

## Tests ##

I added an integration that provisions a 3-node cluster. Also added a bunch of unit tests for other changes.

## Everything ##

There's a `ENABLE_DEBUG` environment variable you can set to enable xtrace, which helps for troubleshooting!


---

Notes:

+ I still need to test this using `/var/db` from an old container to ensure it works fine.
+ **This will not work for existing instances**, because the `aptible` user does not have credentials to edit replication settings (common problem among most of the DB images I have converted unfortunately).
+ I need to update the `config.mk` to use the right tag (right now it builds a test tag I use).

cc @fancyremarker @aaw @blakepettersson 