### PR TITLE
Read certs in --initialize

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -198,6 +198,7 @@ if [[ "$#" -eq 0 ]]; then
 
 elif [[ "$1" == "--initialize" ]]; then
   mongo_environment_full
+  mongo_initialize_certs
   mongo_environment_prefer_cluster_key
 
   # Auto-generate replica set name. We randomize this to ensure multiple MongoDB servers have a different

--- a/test/mongodb-all.bats
+++ b/test/mongodb-all.bats
@@ -100,7 +100,14 @@ source "${BATS_TEST_DIRNAME}/test_helpers.sh"
 
 @test "It should auto-generate certs when none are provided" {
   initialize_mongodb
+  rm "${SSL_DIRECTORY}/mongodb.key" "${SSL_DIRECTORY}/mongodb.crt"
   wait_for_mongodb
   grep "No certs found" "$BATS_TEST_DIRNAME/mongodb.log"
   curl -kv https://localhost:27017 2>&1 | grep "mongodb.example.com"
+}
+
+@test "It should read or generate certs as part of --initialize" {
+  initialize_mongodb
+  [ -f "${SSL_DIRECTORY}/mongodb.crt" ]
+  [ -f "${SSL_DIRECTORY}/mongodb.key" ]
 }


### PR DESCRIPTION
This complements #17 and ensures that we do persist the certificates to disk when `--initialize` runs on v1 stacks.