### PR TITLE
Remove data directory after tests to avoid committing large journal files

### DIFF
--- a/test/test_helpers.sh
+++ b/test/test_helpers.sh
@@ -33,6 +33,8 @@ teardown() {
   PID=$(pgrep mongod) || return 0
   run pkill mongod
   while [ -n "$PID" ] && [ -e "/proc/${PID}" ]; do sleep 0.1; done
+  rm -rf "$DATA_DIRECTORY"
+  rm -rf "$SSL_DIRECTORY"
 }
 
 initialize_mongodb() {


### PR DESCRIPTION
Still waiting on a build to finish locally to confirm this change, but this should shave ~2 GB off the size of the image.