### PR TITLE
Fix 0bb2c52 by putting test data directory removal into a reachable line

### DIFF
--- a/test/test_helpers.sh
+++ b/test/test_helpers.sh
@@ -21,6 +21,8 @@ teardown() {
   # Dump log, if any (facilitates troubleshooting)
   cat "$BATS_TEST_DIRNAME/mongodb.log" || true
   # Actually teardown
+  rm -rf "$DATA_DIRECTORY"
+  rm -rf "$SSL_DIRECTORY"
   export DATA_DIRECTORY="$OLD_DATA_DIRECTORY"
   export SSL_DIRECTORY="$OLD_SSL_DIRECTORY"
   unset OLD_DATA_DIRECTORY
@@ -33,8 +35,6 @@ teardown() {
   PID=$(pgrep mongod) || return 0
   run pkill mongod
   while [ -n "$PID" ] && [ -e "/proc/${PID}" ]; do sleep 0.1; done
-  rm -rf "$DATA_DIRECTORY"
-  rm -rf "$SSL_DIRECTORY"
 }
 
 initialize_mongodb() {


### PR DESCRIPTION
Sorry for the double pull request — I've tested this change on a larger sandbox instance that was able to build the image (my Macbook could not... :confused: ), and have confirmed it fixes two problems with the placement of the lines in the original PR #19.

1. I was running `rm -rf $DATA_DIRECTORY` after the ENV value was reset.
2. I was running the command from a potentially unreachable location (after `PID=$(pgrep mongod) || return 0`).