### PR TITLE
Fix pre-start logic

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -336,6 +336,7 @@ elif [[ "$1" == "--initialize-from" ]]; then
   cat > "$PRE_START_FILE" <<EOM
 #!/bin/bash
 /mongo-scripts/reconfig.sh "$PRIMARY_URL" "$SECONDARY_URL" &
+mv "\$0" "$\{0}.$\(date --iso-8601=seconds).bak"
 EOM
   chmod +x "$PRE_START_FILE"
 

--- a/templates/mongo-scripts/reconfig.sh
+++ b/templates/mongo-scripts/reconfig.sh
@@ -31,6 +31,3 @@ SECONDARY_NAME="$(find_secondary_name )"
 
 run-database.sh --client "$PRIMARY_URL" --eval "var secondary_name='$SECONDARY_NAME'" "/mongo-scripts/primary-enable-secondary.js"
 echo "Reconfigured primary!"
-
-mv "$0" "${0}.$(date --iso-8601=seconds).bak"
-echo "Moved this file out"


### PR DESCRIPTION
It's the pre-start script that needs to be moved out so that it doesn't
re-run on restart; not the reconfig.sh script it runs.

Not sure what I was thinking here (this wouldn't have caused any issues besides spurious logging, though)

cc @fancyremarker 