### PR TITLE
Add --initialize-backup command

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -29,12 +29,9 @@ ADD bin/utilities.sh /usr/bin/
 
 ADD templates/mongo-scripts /mongo-scripts
 
-# Integration tests
+# Unit tests (executed by test.sh)
 ADD <%= ENV.fetch 'TAG' %>/test /tmp/test
 ADD test /tmp/test
-RUN apt-install curl \
- && bats /tmp/test \
- && apt-get remove -y curl && apt-get -y autoremove
 
 VOLUME ["$DATA_DIRECTORY"]
 VOLUME ["$SSL_DIRECTORY"]

--- a/bin/parse_mongo_url.py
+++ b/bin/parse_mongo_url.py
@@ -55,16 +55,16 @@ def prepare_options(u):
 
     # Prepare our Mongo options
     options = [
-        "--host", quote(u.hostname),
-        "--port", quote(str(u.port or DEFAULT_MONGO_PORT)),
+        "--host", u.hostname,
+        "--port", str(u.port or DEFAULT_MONGO_PORT),
     ]
 
     for opt, val in zip(["username", "password"], [u.username, u.password]):
         if val:
-            options.extend(["--{0}".format(opt), quote(val)])
+            options.extend(["--{0}".format(opt), val])
 
     if use_ssl:
-        options.extend(["--ssl", "--sslCAFile", quote(SSL_CA_FILE)])
+        options.extend(["--ssl", "--sslCAFile", SSL_CA_FILE])
         if not check_ssl:
             options.append("--sslAllowInvalidCertificates")
 
@@ -74,7 +74,7 @@ def prepare_options(u):
         "username": u.username,
         "password": u.password,
         "database": u.path.lstrip('/'),
-        "mongo_options": " ".join(options)
+        "mongo_options": options
     }
 
 
@@ -91,7 +91,12 @@ def main(mongo_url):
 
     # And now provide this to the shell
     for k, v in prepare_options(u).items():
-        print "{0}={1}".format(k, quote(str(v)))
+        if isinstance(v, list):
+            array = "({0})".format(" ".join([quote(o) for o in v]))
+            print "{0}={1}".format(k, array)
+        else:
+            print "{0}={1}".format(k, quote(str(v)))
+
 
 
 if __name__ == "__main__":

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -270,8 +270,7 @@ elif [[ "$1" == "--initialize-backup" ]]; then
   echo "$CLUSTER_KEY" > "$CLUSTER_KEY_FILE"
   chmod 600 "$CLUSTER_KEY_FILE"
 
-  OLD_REPL_SET_NAME="$(cat "$REPL_SET_NAME_FILE")"
-
+  # Generate a new replica set name
   REPL_SET_NAME="rs$(pwgen -s 12)"
   echo "$REPL_SET_NAME" > "$REPL_SET_NAME_FILE"
 
@@ -301,9 +300,7 @@ elif [[ "$1" == "--initialize-backup" ]]; then
   done
 
   # Delete the old replica set
-  mongo "${mongo_options[@]}" \
-    --eval "var replica_set_name = '${OLD_REPL_SET_NAME}';" \
-    "/mongo-scripts/remove-replica-set.js"
+  mongo "${mongo_options[@]}" "/mongo-scripts/remove-replica-set.js"
 
   # Shut it down
   kill "$(cat "$PID_PATH_STAGE_1")"

--- a/templates/mongo-scripts/remove-replica-set.js
+++ b/templates/mongo-scripts/remove-replica-set.js
@@ -1,7 +1,6 @@
-// Expect replica_set_name to be set as a variable.
 var local = db.getSiblingDB('local');
-var ret = local.system.replset.remove({ _id: replica_set_name });
+var ret = local.dropDatabase();
 
-if (ret.nRemoved <= 0) {
+if (!ret.ok) {
   quit(1);
 }

--- a/templates/mongo-scripts/remove-replica-set.js
+++ b/templates/mongo-scripts/remove-replica-set.js
@@ -1,0 +1,7 @@
+// Expect replica_set_name to be set as a variable.
+var local = db.getSiblingDB('local');
+var ret = local.system.replset.remove({ _id: replica_set_name });
+
+if (ret.nRemoved <= 0) {
+  quit(1);
+}

--- a/test-helpers.sh
+++ b/test-helpers.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+function _wait_for_mongo_exec {
+  local container="$1"
+  local command="$2"
+
+  local mongo_args=(
+    "--ssl" "--sslAllowInvalidCertificates"
+    "--quiet"
+    "--eval" "$command"
+  )
+
+  for _ in $(seq 1 1000); do
+    if docker exec -it "$container" mongo "${mongo_args[@]}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  return 1;
+}
+
+function wait_for_mongo {
+  local container="$1"
+
+  if _wait_for_mongo_exec "$container" "quit(0)"; then
+    return 0
+  fi
+
+  echo "DB never came online"
+  docker logs "$container"
+  return 1
+}
+
+function wait_for_primary {
+  local container="$1"
+
+  if _wait_for_mongo_exec "$container" 'quit(db.isMaster()["ismaster"] ? 0 : 1)'; then
+    return 0
+  fi
+
+  echo "DB never became primary"
+  docker logs "$container"
+  return 1
+}
+
+function quietly {
+  local out err
+
+  out="$(mktemp)"
+  err="$(mktemp)"
+
+  if "$@" > "$out" 2> "$err"; then
+    rm "$out" "$err"
+    return 0;
+  else
+    local status="$?"
+    echo    "COMMAND FAILED:" "$@"
+    echo    "STATUS:         ${status}"
+    sed 's/^/STDOUT:         /' < "$out"
+    sed 's/^/STDERR:         /' < "$err"
+    return "$status"
+  fi
+}

--- a/test-initialize-backup.sh
+++ b/test-initialize-backup.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+. ./test-helpers.sh
+
+IMG="$1"
+
+MONGO_CONTAINER="mongo"
+DATA_CONTAINER="${MONGO_CONTAINER}-data"
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$MONGO_CONTAINER" "$DATA_CONTAINER" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+quietly cleanup
+
+echo "Creating data container"
+docker create --name "$DATA_CONTAINER" "$IMG"
+
+echo "Initialize DB"
+quietly docker run -it --rm \
+  -e USERNAME=user -e PASSPHRASE=pass -e DATABASE=db \
+  -e EXPOSE_HOST=127.0.0.1 -e EXPOSE_PORT_27217=27217 \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG" --initialize
+
+echo "Start DB"
+quietly docker run -d --name="$MONGO_CONTAINER" \
+  -e EXPOSE_HOST=127.0.0.1 -e EXPOSE_PORT_27217=27217 \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG" 
+
+echo "Wait for DB to come online"
+wait_for_mongo "$MONGO_CONTAINER"
+
+echo "Wait for DB to transition to PRIMARY"
+wait_for_primary "$MONGO_CONTAINER"
+
+echo "Stop DB"
+docker stop "$MONGO_CONTAINER"
+docker rm "$MONGO_CONTAINER"
+
+echo "Initialize Restore"
+quietly docker run -it --rm \
+  -e USERNAME=user -e PASSPHRASE=pass -e DATABASE=db \
+  -e EXPOSE_HOST=127.0.0.1 -e EXPOSE_PORT_27217=27217 \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG" --initialize-backup 
+
+echo "Start DB after restore"
+quietly docker run -d --name="$MONGO_CONTAINER" \
+  -e EXPOSE_HOST=127.0.0.1 -e EXPOSE_PORT_27217=27217 \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG"
+
+echo "Wait for DB to come online after restore"
+wait_for_mongo "$MONGO_CONTAINER"
+
+echo "Wait for DB to transition to PRIMARY after restore"
+wait_for_primary "$MONGO_CONTAINER"
+
+echo "TEST OK"

--- a/test-restart.sh
+++ b/test-restart.sh
@@ -2,6 +2,8 @@
 set -o errexit
 set -o nounset
 
+. ./test-helpers.sh
+
 IMG="$1"
 
 MONGO_CONTAINER="mongo"
@@ -12,40 +14,26 @@ function cleanup {
   docker rm -f "$MONGO_CONTAINER" "$DATA_CONTAINER" >/dev/null 2>&1 || true
 }
 
-function wait_for_mongo {
-  for _ in $(seq 1 1000); do
-    if docker exec -it "$MONGO_CONTAINER" mongo --ssl --sslAllowInvalidCertificates --quiet --eval 'quit(0)' >/dev/null 2>&1; then
-      return 0
-    fi
-    sleep 0.1
-  done
-
-  echo "DB never came online"
-  docker logs "$MONGO_CONTAINER"
-  return 1
-}
-
 trap cleanup EXIT
-cleanup
+quietly cleanup
 
 echo "Creating data container"
 docker create --name "$DATA_CONTAINER" "$IMG"
 
 echo "Starting DB"
-docker run -it --rm \
+quietly docker run -it --rm \
   -e USERNAME=user -e PASSPHRASE=pass -e DATABASE=db \
   -e EXPOSE_HOST=127.0.0.1 -e EXPOSE_PORT_27217=27217 \
   --volumes-from "$DATA_CONTAINER" \
-  "$IMG" --initialize \
-  >/dev/null 2>&1
+  "$IMG" --initialize
 
-docker run -d --name="$MONGO_CONTAINER" \
+quietly docker run -d --name="$MONGO_CONTAINER" \
   -e EXPOSE_HOST=127.0.0.1 -e EXPOSE_PORT_27217=27217 \
   --volumes-from "$DATA_CONTAINER" \
   "$IMG"
 
 echo "Waiting for DB to come online"
-wait_for_mongo
+wait_for_mongo "$MONGO_CONTAINER"
 
 echo "Verifying DB shutdown message isn't present"
 docker logs "$MONGO_CONTAINER" 2>&1 | grep -vqiE "dbexit.*(rc: 0|really exit)"
@@ -57,7 +45,7 @@ docker top "$MONGO_CONTAINER"
 docker restart -t 10 "$MONGO_CONTAINER"
 
 echo "Waiting for DB to come back online"
-wait_for_mongo
+wait_for_mongo "$MONGO_CONTAINER"
 
 echo "DB came back online; checking for clean shutdown and recovery"
 date
@@ -70,5 +58,5 @@ docker kill -s KILL "$MONGO_CONTAINER"
 docker start "$MONGO_CONTAINER"
 
 echo "Waiting for DB to come back online"
-wait_for_mongo
+wait_for_mongo "$MONGO_CONTAINER"
 docker logs "$MONGO_CONTAINER" 2>&1 | grep -qiE "(recovering data from the last clean checkpoint|recover done)"

--- a/test.sh
+++ b/test.sh
@@ -4,8 +4,21 @@ set -o nounset
 
 IMG="$REGISTRY/$REPOSITORY:$TAG"
 
+echo "Unit Tests..."
+docker run -it --rm --entrypoint "bash" "$IMG" \
+  -c "apt-install curl >/dev/null && bats /tmp/test"
+
+echo
+echo "Restart Test..."
 ./test-restart.sh "$IMG"
+
+echo
+echo "Replication Test..."
 ./test-replication.sh "$IMG"
+
+echo
+echo "Initialize Backup Test..."
+./test-initialize-backup.sh "$IMG"
 
 echo "#############"
 echo "# Tests OK! #"


### PR DESCRIPTION
This command will be triggered by Sweetness in order to purge the local
replica set configuration when initializing from a backup.

This ensures the new database comes online in a standalone replica set,
whereas it would otherwise attempt to join the original database's
replica set (and transition to `REMOVED` in the process, since it's not
a member of that replica set).

---

cc @fancyremarker 
