### PR TITLE
Auto-configure from APTIBLE_CONTAINER_SIZE

### DIFF
--- a/3.2/test/mongodb-3.2.bats
+++ b/3.2/test/mongodb-3.2.bats
@@ -20,3 +20,15 @@ source "${BATS_TEST_DIRNAME}/test_helpers.sh"
   run run-database.sh --client "$DATABASE_URL_NO_SSL" --eval "$QUERY"
   [ "$status" -ne "0" ]
 }
+
+@test "It should autotune for a 2GB container" {
+  initialize_mongodb
+  APTIBLE_CONTAINER_SIZE=2048 wait_for_mongodb
+  run-database.sh --client "$ADMIN_DATABASE_URL" --eval "$PRINT_RAM_QUERY" | grep 1024
+}
+
+@test "It should autotune for a 4GB container" {
+  initialize_mongodb
+  APTIBLE_CONTAINER_SIZE=4096 wait_for_mongodb
+  run-database.sh --client "$ADMIN_DATABASE_URL" --eval "$PRINT_RAM_QUERY" | grep 2048
+}

--- a/3.4/test/mongodb-3.4.bats
+++ b/3.4/test/mongodb-3.4.bats
@@ -20,3 +20,21 @@ source "${BATS_TEST_DIRNAME}/test_helpers.sh"
   run run-database.sh --client "$DATABASE_URL_NO_SSL" --eval "$QUERY"
   [ "$status" -ne "0" ]
 }
+
+@test "It should autotune for a 512MB container" {
+  initialize_mongodb
+  APTIBLE_CONTAINER_SIZE=512 wait_for_mongodb
+  run-database.sh --client "$ADMIN_DATABASE_URL" --eval "$PRINT_RAM_QUERY" | grep 256
+}
+
+@test "It should autotune for a 1GB container" {
+  initialize_mongodb
+  APTIBLE_CONTAINER_SIZE=1024 wait_for_mongodb
+  run-database.sh --client "$ADMIN_DATABASE_URL" --eval "$PRINT_RAM_QUERY" | grep 512
+}
+
+@test "It should autotune for a 2GB container" {
+  initialize_mongodb
+  APTIBLE_CONTAINER_SIZE=2048 wait_for_mongodb
+  run-database.sh --client "$ADMIN_DATABASE_URL" --eval "$PRINT_RAM_QUERY" | grep 1024
+}

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -26,6 +26,7 @@ RUN mkdir -p "${DATA_DIRECTORY}" "${SSL_DIRECTORY}"
 ADD bin/run-database.sh /usr/bin/
 ADD bin/parse_mongo_url.py /usr/bin/
 ADD bin/utilities.sh /usr/bin/
+ADD bin/autotune /usr/local/bin/
 
 ADD templates/mongo-scripts /mongo-scripts
 

--- a/bin/autotune
+++ b/bin/autotune
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+import sys
+import os
+
+# NOTE: pipes.quote is deprecated in 2.7, if upgrading to 3.x, use shlex.quote
+from pipes import quote
+
+CACHE_SIZE_PARAM = '--wiredTigerCacheSizeGB'
+
+
+def generate_config(mongo_version, ram_mb):
+    if mongo_version < (3, 2):
+        return []
+
+    cache_size_mb = max(
+        ram_mb / 2,
+        0.6 * ram_mb - 1024
+    )
+
+    if mongo_version >= (3, 3, 5):
+        # We can use a float here https://jira.mongodb.org/browse/SERVER-23624
+        cache_size_gb = round(float(cache_size_mb) / 1024, 2)
+        return [CACHE_SIZE_PARAM, str(cache_size_gb)]
+
+    cache_size_gb = int(cache_size_mb / 1024)
+    if cache_size_gb > 0:
+        return [CACHE_SIZE_PARAM, str(cache_size_gb)]
+
+    return []
+
+
+def main():
+    raw_version = os.environ['MONGO_VERSION']
+    mongo_version = tuple(int(x) for x in raw_version.split('.'))
+    ram_mb = int(os.environ.get('APTIBLE_CONTAINER_SIZE', '1024'))
+
+    config = generate_config(mongo_version, ram_mb)
+    print ' '.join(quote(param) for param in config)
+
+
+def test():
+    test_cases = [
+        [(2, 6, 11), 1024, []],
+
+        [(3, 2, 17), 0.5 * 1024, []],
+        [(3, 2, 17), 1024, []],
+        [(3, 2, 17), 2 * 1024, [CACHE_SIZE_PARAM, '1']],
+        [(3, 2, 17), 4 * 1024, [CACHE_SIZE_PARAM, '2']],
+        [(3, 2, 17), 7 * 1024, [CACHE_SIZE_PARAM, '3']],
+        [(3, 2, 17), 7 * 1024, [CACHE_SIZE_PARAM, '3']],
+        [(3, 2, 17), 15 * 1024, [CACHE_SIZE_PARAM, '8']],
+
+        [(3, 4, 10), 1024, [CACHE_SIZE_PARAM, '0.5']],
+        [(3, 4, 10), 2 * 1024, [CACHE_SIZE_PARAM, '1.0']],
+        [(3, 4, 10), 4 * 1024, [CACHE_SIZE_PARAM, '2.0']],
+        [(3, 4, 10), 7 * 1024, [CACHE_SIZE_PARAM, '3.5']],
+        [(3, 4, 10), 7 * 1024, [CACHE_SIZE_PARAM, '3.5']],
+        [(3, 4, 10), 15 * 1024, [CACHE_SIZE_PARAM, '8.0']],
+    ]
+
+    for version, size, expected_config in test_cases:
+        prefix = "MongoDB {0} at {1}GB".format(
+            '.'.join(str(x) for x in version), size / 1024
+        )
+
+        real_config = generate_config(version, size)
+
+        m = "{0}: configuration differs\n  Got: {1}\n  Expected: {2}".format(
+            prefix, real_config, expected_config
+        )
+        assert real_config == expected_config, m
+
+    sys.stderr.write("OK\n")
+
+
+def usage(program):
+    sys.stderr.write("Usage: {0} [--test]\n".format(program))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        main()
+    elif len(sys.argv) == 2 and sys.argv[1] == '--test':
+        test()
+    else:
+        usage(sys.argv[0])

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -172,6 +172,10 @@ function startMongod () {
     "--auth"
   )
 
+  mongod_options+=(
+    $(/usr/local/bin/autotune)
+  )
+
   if [ -f "$REPL_SET_NAME_FILE" ] && [ -f "$CLUSTER_KEY_FILE" ]; then
     # We have replica set configuration! Start with replica set options.
     mongod_options+=(

--- a/test/autotune.bats
+++ b/test/autotune.bats
@@ -1,0 +1,5 @@
+#!/usr/bin/env bats
+
+@test "autotune should pass its self-tests" {
+  /usr/local/bin/autotune --test
+}

--- a/test/test_helpers.sh
+++ b/test/test_helpers.sh
@@ -11,6 +11,8 @@ setup() {
   export DATABASE_CLUSTER_KEY="key1234"
   export DATABASE_URL_NO_SSL="mongodb://$DATABASE_USER:$DATABASE_PASSWORD@localhost/db"
   export DATABASE_URL="$DATABASE_URL_NO_SSL?ssl=true&x-sslVerify=false"
+  export ADMIN_DATABASE_URL="mongodb://$DATABASE_USER:$DATABASE_PASSWORD@localhost/admin?ssl=true&x-sslVerify=false"
+  export PRINT_RAM_QUERY="print(db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] / 1024 / 1024)"
   rm -rf "$DATA_DIRECTORY"
   rm -rf "$SSL_DIRECTORY"
   mkdir -p "$DATA_DIRECTORY"


### PR DESCRIPTION
This adds auto configuration for wiredTigerCacheSizeGB, based on
APTIBLE_CONTAINER_SIZE.

We're not exactly following the MongoDB guidelines, because
unfortunately, they offer contradicting advice:

- They say we should use 1 GB or more
- They also say we should use less than the container size

Also, float values for wiredTigerCacheSizeGB are only supported in
MongoDB 3.3 and up: https://jira.mongodb.org/browse/SERVER-23624, so we
have to accommodate this as well on MongoDB 3.2.

---

cc @fancyremarker 
fyi @UserNotFound 