### PR TITLE
Skip --initialize-backup steps for standalone databases

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -346,6 +346,11 @@ elif [[ "$1" == "--initialize" ]]; then
   mongo_shutdown_background "$PID_PATH_STAGE_2"
 
 elif [[ "$1" == "--initialize-backup" ]]; then
+  # No need to initialize replica set on a backup from a standalone database
+  if [[ ! -f "$REPL_SET_NAME_FILE" ]]; then
+    exit 0
+  fi
+
   # There will be no --discover when restoring, so we expect our environment to be pre-configured.
   mongo_environment_full
   mongo_initialize_certs


### PR DESCRIPTION
In other words, if no replica set name file exists, and therefore no replica set exists, don't bother re-initializing the replica set. (Attempting to re-initialize the replica set could fail due to the absence of a known, privileged user in the `admin` database.)

---

Thanks @krallin for walking me through this. I've tested to confirm this works; please let me know if you think any test additions/modifications are appropriate here, and I'll write them.