### PR TITLE
Initialize replicas with a lower priority.

### DIFF
--- a/templates/mongo-scripts/primary-enable-secondary.js
+++ b/templates/mongo-scripts/primary-enable-secondary.js
@@ -8,7 +8,7 @@ var member;
 for (var i = 0; i < conf["members"].length; i++) {
   member = conf["members"][i];
   if (member.host === secondary_name ) {
-    member.priority = 1;
+    member.priority = 0.5;
     member.votes = 1;
   }
 }

--- a/test/assert-votes.js
+++ b/test/assert-votes.js
@@ -1,10 +1,22 @@
 var conf = rs.conf();
 var ret = 0;
+var desired_priority = 0;
 
 for (var i = 0; i < conf["members"].length; i++) {
+
   member = conf["members"][i];
+
+  switch(member.host) {
+    case "mongodb-r1:27117":
+      desired_priority = 1;
+      break;
+    default:
+      desired_priority = 0.5;
+  }
+
+
   if (
-      (member.priority !== 1) || (member.votes !== 1)
+      (member.priority !== desired_priority) || (member.votes !== 1)
   ) {
     print("MISCONFIGURED: " + member.host);
     printjson(member);


### PR DESCRIPTION
The Deploy API has a one to many relationship between a database and its dependents, and many users see a Mongo replica set through this lens: there is a "primary" node, and others are "replicas".  However, Mongo is clustered, and by default, any node has an equal chance of being elected to be the primary/writable database.

This chance of a node being the primary member is defined by its [member priority](https://docs.mongodb.com/manual/reference/replica-configuration/#rsconf.members[n].priority). 
This PR sets the priority of any newly created "replica" to a lower value (0.5) than the "primary" Database (1).

For instance, if you create a three member replica set:

* `aptible db:create mongo-prod`
* `aptible db:replicate mongo-prod mongo-prod-replica-1`
* `aptible db:replicate mongo-prod mongo-prod-replica-2`

As long as it is available, the node `mongo-prod` should be the primary/writable node of the replica set, meaning you should always be able to `aptible db:tunnel mongo-prod` and find that it is a primary/writable database.

This PR will not affect any existing databases, nor is there any requirement to update existing replica sets, though this has and will always be possible to do: https://docs.mongodb.com/manual/tutorial/adjust-replica-set-member-priority/

