### PR TITLE
Wait a bit to be sure the socket is closed.

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -272,6 +272,10 @@ function mongo_shutdown_background () {
   # Terminate MongoDB and wait for it to exit
   kill "$(cat "$pidPath")"
   while [ -s "${DATA_DIRECTORY}/mongod.lock" ]; do sleep 0.1; done
+
+  # This above does not always ensure Mongo has fully exited, and we see this error at times:
+  # [initandlisten] Failed to set up listener: SocketException: Address already in use
+  sleep 3
 }
 
 dump_directory="mongodump"


### PR DESCRIPTION
Naively try to be sure the socket is close when restarting Mongo, to avoid this error:

```2021-07-12T20:26:38.451+0000 I CONTROL  [signalProcessingThread] got signal 15 (Terminated), will terminate after current cmd ends
2021-07-12T20:26:38.451+0000 I NETWORK  [signalProcessingThread] shutdown: going to close listening sockets...
2021-07-12T20:26:38.451+0000 I NETWORK  [signalProcessingThread] removing socket file: /tmp/mongodb-27017.sock
2021-07-12T20:26:38.452+0000 I CONTROL  [signalProcessingThread] Shutting down free monitoring
2021-07-12T20:26:38.452+0000 I FTDC     [signalProcessingThread] Shutting down full-time diagnostic data capture
2021-07-12T20:26:38.452+0000 I STORAGE  [signalProcessingThread] WiredTigerKVEngine shutting down
2021-07-12T20:26:38.875+0000 I STORAGE  [signalProcessingThread] shutdown: removing fs lock...
2021-07-12T20:26:38.875+0000 I CONTROL  [signalProcessingThread] now exiting
2021-07-12T20:26:38.875+0000 I CONTROL  [signalProcessingThread] shutting down with code:0

2021-07-12T20:26:39.007+0000 I CONTROL  [initandlisten] MongoDB starting : pid=60 port=27017 dbpath=/var/db 64-bit host=mongodb
2021-07-12T20:26:39.008+0000 I CONTROL  [initandlisten] db version v4.0.3
2021-07-12T20:26:39.008+0000 I CONTROL  [initandlisten] git version: 7ea530946fa7880364d88c8d8b6026bbc9ffa48c
2021-07-12T20:26:39.008+0000 I CONTROL  [initandlisten] OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019
2021-07-12T20:26:39.008+0000 I CONTROL  [initandlisten] allocator: tcmalloc
2021-07-12T20:26:39.008+0000 I CONTROL  [initandlisten] modules: none
2021-07-12T20:26:39.008+0000 I CONTROL  [initandlisten] build environment:
2021-07-12T20:26:39.008+0000 I CONTROL  [initandlisten]     distmod: debian92
2021-07-12T20:26:39.008+0000 I CONTROL  [initandlisten]     distarch: x86_64
2021-07-12T20:26:39.008+0000 I CONTROL  [initandlisten]     target_arch: x86_64
2021-07-12T20:26:39.008+0000 E STORAGE  [initandlisten] Failed to set up listener: SocketException: Address already in use
```